### PR TITLE
fix(formatting): Fix the formatting of md files + add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.DEFAULT_GOAL := help
+
+formatting: ## Fix the formatting of md files
+	@npx prettier --write .
+
+help: ## This help.
+	@echo 'Available targets:'
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.PHONY: help formatting

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Documentation Signaux Faibles
 
 ## Table des matières
+
 - [Présentation du projet](#présentation-du-projet) (vide)
 - [Prise en Main](prise-en-main.md) (vide)
 - [Architecture logicielle](architecture-logicielle.md) (wip)
@@ -12,13 +13,15 @@
 - [Supervision](supervision.md) (wip)
 
 ## Présentation du projet
+
 L'organisation github [Signaux-Faibles](https://github.com/signaux-faibles/) regroupe tous les outils développés au sein de la startup d'état [Signaux Faibles](https://beta.gouv.fr/startups/signaux-faibles.html).
 
 L'objectif de ces outils est de fournir les outils techniques nécessaires à la mise en oeuvre de la détection algorithmique ainsi que la diffusion des résultats de cette détection auprès des utilisateurs.
 
 ## Logiciels
+
 - [signauxfaibles-web](https://github.com/signaux-faibles/signauxfaibles-web) est l'interface utilisateur destinée aux agents publics
-- [opensignauxfaibles](https://github.com/signaux-faibles/opensignauxfaibles) contient le socle technique permettant la mise en oeuvre des méthodes de machine learning 
+- [opensignauxfaibles](https://github.com/signaux-faibles/opensignauxfaibles) contient le socle technique permettant la mise en oeuvre des méthodes de machine learning
 - [datapi](https://github.com/signaux-faibles/datapi) est une api orientée sur l'hébergement et l'échange de données dans un contexte de gestion complexe des attributions
 - [goup](https://github.com/signaux-faibles/goup) est une api destinée à permettre le transfert des fichiers bruts avec un protocole flexible et fiable basé sur http (voir [tus](https://github.com/tus))
 - MLsegmentr(https://github.com/signaux-faibles/MLsegmentr) est un package R destiné à l'industrialisation de l'évaluation d'algorithmes

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ L'organisation github [Signaux-Faibles](https://github.com/signaux-faibles/) reg
 
 L'objectif de ces outils est de fournir les outils techniques nécessaires à la mise en oeuvre de la détection algorithmique ainsi que la diffusion des résultats de cette détection auprès des utilisateurs.
 
-## Logiciels
+## Logiciels
 
 - [signauxfaibles-web](https://github.com/signaux-faibles/signauxfaibles-web) est l'interface utilisateur destinée aux agents publics
 - [opensignauxfaibles](https://github.com/signaux-faibles/opensignauxfaibles) contient le socle technique permettant la mise en oeuvre des méthodes de machine learning

--- a/algorithme-evaluation.md
+++ b/algorithme-evaluation.md
@@ -1,30 +1,31 @@
-
-
 # Évaluation de l'algorithme
-## Découpage en échantillon d'entraînement, de validation et de test. 
+
+## Découpage en échantillon d'entraînement, de validation et de test.
 
 Lorsque différents algorithmes sont explorés, alors les données sont scindés en échantillons d'entraînement, de validation et de test.
 Par défaut, les proportions de ces échantillons sont 60%, 20% et 20% respectivement. Cette scission est parfaitement reproductible (cf paragraphe consacré)
 
-L'échantillon d'entraînement sert à l'entraînement de différents algorithmes, celui de validation à la comparaison des résultats, et celui de test n'est que rarement sollicité pour avoir une évaluation de la performance réelle de l'algorithme. 
+L'échantillon d'entraînement sert à l'entraînement de différents algorithmes, celui de validation à la comparaison des résultats, et celui de test n'est que rarement sollicité pour avoir une évaluation de la performance réelle de l'algorithme.
 
-Afin d'éviter de fuite d'information d'un échantillon vers l'autre, les différentes "vues" d'un même établissement à des périodes différentes, et les établissements d'une même entreprise seront toujours regroupées dans le même échantillon. 
+Afin d'éviter de fuite d'information d'un échantillon vers l'autre, les différentes "vues" d'un même établissement à des périodes différentes, et les établissements d'une même entreprise seront toujours regroupées dans le même échantillon.
 
-Par défaut, **les "signaux forts"**, c'est-à-dire les entreprises pour lesquelles on peut affirmer avec certitudes qu'elles tombent dans la cible d'apprentissage, **sont retirés des échantillons d'évaluation (validation, test)**. 
-Ces entreprises sont les entreprises déjà en procédure collective, ou ayant déjà subi trois mois consécutifs de dette sur les cotisations sociales. 
+Par défaut, **les "signaux forts"**, c'est-à-dire les entreprises pour lesquelles on peut affirmer avec certitudes qu'elles tombent dans la cible d'apprentissage, **sont retirés des échantillons d'évaluation (validation, test)**.
+Ces entreprises sont les entreprises déjà en procédure collective, ou ayant déjà subi trois mois consécutifs de dette sur les cotisations sociales.
 L'évaluation donne ainsi une image fidèle de la capacité prédictive de l'algorithme.
 
 ## Choix de la métrique
-Après retrait des "signaux forts" (cf paragraphe précédent), la cible à détecter représente à peine 3% de l'échantillon d'entreprise. Il s'agit donc d'un échantillon très biaisé. 
 
-Le choix de l'**aire sous la courbe précision-rappel** comme métrique est compatible avec ce biais. 
+Après retrait des "signaux forts" (cf paragraphe précédent), la cible à détecter représente à peine 3% de l'échantillon d'entreprise. Il s'agit donc d'un échantillon très biaisé.
 
-## Reproductibilité de l'évaluation. 
+Le choix de l'**aire sous la courbe précision-rappel** comme métrique est compatible avec ce biais.
 
-Des mesures ont été prises pour la reproductibilité de l'évaluation. 
+## Reproductibilité de l'évaluation.
+
+Des mesures ont été prises pour la reproductibilité de l'évaluation.
 
 ### Intégration dans R
-D'abord, l'échantillonnage des données importées sous R doit être reproductible. 
+
+D'abord, l'échantillonnage des données importées sous R doit être reproductible.
 Pour cela, un nombre aléatoire est sauvegardé à même la base de données, pour les données historiques susceptibles d'être échantillonnées, à savoir les données de 2015 et 2016.
 
 Ce nombre aléatoire est généré dans un fichier à partir des données Sirene, puis intégré au même titre que les autres données, ce qui présente plusieurs avantages:
@@ -32,19 +33,18 @@ Ce nombre aléatoire est généré dans un fichier à partir des données Sirene
     * La conservation de l'historique des batchs successifs dans DataRaw
     * Le nombre aléatoire est transféré à la collection Features sous l'intitulé "random_order"
     * Il est possible d'ajouter de nouvelles entreprises, par exemple issues de nouvelles régions, sans toucher aux anciens champs. Ainsi, même après ajout de ces nouveaux établissements, un échantillonnage sur l'ancien périmètre renverra le même résultat.
-    * Cela offre la possibilité future de compléter avec des informations d'échantillonnage directement dans la base: échantillon de test/validation/entraînement, ou validation croisée etc. 
+    * Cela offre la possibilité future de compléter avec des informations d'échantillonnage directement dans la base: échantillon de test/validation/entraînement, ou validation croisée etc.
     * Un fichier .csv est facilement échangeable d'une personne à l'autre
 
 ### Reproductibilité des traitements dans R
 
-La reproductibilité des traitements dans R est assurée par l'utilisation de suites pseudo-random et d'une *seed*. 
+La reproductibilité des traitements dans R est assurée par l'utilisation de suites pseudo-random et d'une _seed_.
 
-C'est notamment le cas dans le découpage en différents échantillons, la préparation des données (ou un bruit peut être appliqué sur les données d'entraînement afin d'éviter le suréchantillonnage), ou encore dans l'entraînement de l'algorithme lorsque celui-ci dépend de composantes aléatoires. 
+C'est notamment le cas dans le découpage en différents échantillons, la préparation des données (ou un bruit peut être appliqué sur les données d'entraînement afin d'éviter le suréchantillonnage), ou encore dans l'entraînement de l'algorithme lorsque celui-ci dépend de composantes aléatoires.
 
 Il est à noter que pour la constitution des échantillons d'entraînement, de test et de validation, les données sont d'abord triées, afin que le résultat ne dépende pas de leur ordre.
 
-Cette reproducibilité est évidemment uniquement assuré en cas de paramètres identiques (pour l'algorithme, taille de l'échantillon initial, proportions dans les échantillons de validation, de test et de validation). 
-
+Cette reproducibilité est évidemment uniquement assuré en cas de paramètres identiques (pour l'algorithme, taille de l'échantillon initial, proportions dans les échantillons de validation, de test et de validation).
 
 # Evolution de l'algorithme
 

--- a/architecture-logicielle.md
+++ b/architecture-logicielle.md
@@ -2,7 +2,7 @@
 
 ## Objectifs du dispositif
 
-- récolter les données brutes en provenance des partenaires (goup + stockage POSIX) 
+- récolter les données brutes en provenance des partenaires (goup + stockage POSIX)
 - traiter/importer les données brutes (opensignauxfaibles + mongodb)
 - raffiner les données pour obtenir les variables nécessaires à la bonne marche de l'algorithme (opensignauxfaibles + mongodb)
 - exécuter la détection algorithmique (opensignauxfaibles + mongodb)
@@ -18,11 +18,12 @@ Plus de détails sont disponibles [ici](https://github.com/signaux-faibles/goup)
 
 ### Objectif
 
-goup permet aux partenaires de déposer les fichiers de données brutes sur la plateforme.  
+goup permet aux partenaires de déposer les fichiers de données brutes sur la plateforme.
 
 ### Composition
 
 goup est basé sur [tusd](https://github.com/tus/tusd) et lui ajoute des fonctionnalités:
+
 - authentification par JWT
 - espaces privatifs par utilisateurs (gestion des droits et des chemins)
 - supprime la possibilité de télécharger les fichiers
@@ -30,8 +31,7 @@ goup est basé sur [tusd](https://github.com/tus/tusd) et lui ajoute des fonctio
 ### Authentification JWT
 
 En l'absence d'un JWT valide, le service refuse les sollicitations.  
-Ce token devra en plus fournir dans son chargement une propriété `goup-path` correspondant au nom d'utilisateur posix ciblé par le versement.  
-
+Ce token devra en plus fournir dans son chargement une propriété `goup-path` correspondant au nom d'utilisateur posix ciblé par le versement.
 
 ### Traitement des fichiers uploadés
 
@@ -41,27 +41,29 @@ Ce token devra en plus fournir dans son chargement une propriété `goup-path` c
 - Les droits sont fixés sur le fichier pour limiter l'accès aux utilisateurs souhaités (grace à la propriété `goup-path`)
 - Un lien est créé dans l'espace de stockage ad-hoc.
 
-
 ### Structure du stockage
 
 Le fichiers uploadés sont matérialisés sur le disque dur par deux fichiers nommés d'après le hash de l'upload généré par TUS:
+
 - un fichier .bin qui contient les données du fichier
 - un fichier .info qui contient les métadonnées
 
 Le stockage est organisé dans 2 répertoires permanents:
+
 - tusd: espace de traitement des upload par le serveur et accessible uniquement par ce dernier
 - public: espace commun à tous les utilisateurs
 
 1 répertoire privé pour chaque utilisateur (voir exemple ci-dessous)
 
 Voici l'état du stockage après l'upload de 4 fichiers par deux utilisateurs:
+
 - file1: user1, envoi public
 - file2: user1, envoi privé
 - file3: user2, envoi public
 - file4: user2, envoie privé
 
 ```
-chemin                           user:group            mode 
+chemin                           user:group            mode
 
 .
 +-- tusd                         goup:goup             770
@@ -89,6 +91,7 @@ chemin                           user:group            mode
 ### dépendances logicielles
 
 goup est développé en go (v1.10) et exploite les packages suivants:
+
 - https://github.com/tus/tusd
 - https://github.com/tus/tusd/filestore
 - https://github.com/appleboy/gin-jwt
@@ -101,6 +104,7 @@ goup est développé en go (v1.10) et exploite les packages suivants:
 ### Objectif
 
 opensignauxfaibles se charge du traitement des données:
+
 - import des fichiers bruts
 - calcul des données d'entrée de l'algorithme
 - stockage des résultats
@@ -112,6 +116,7 @@ Cette brique intègre le stockage de l'historique des données brutes, mais auss
 #### dbmongo
 
 Ce module est écrit en go (1.10) et centralise les fonctions de traitement des données suivantes:
+
 - analyse des fichiers bruts
 - conversion/insert dans mongodb
 - ordonnancement des traitements mapreduce/aggregations mongodb
@@ -145,6 +150,7 @@ Ce module permet le traitement algorithmique. (à écrire)
 ### Flux de traitement
 
 ![schéma](architecture-logicielle/workflow-osf.png)
+
 1. Lecture des fichiers bruts ([dbmongo](#dbmongo))
 1. Les données brutes sont converties et insérées dans mongodb ([dbmongo](#dbmongo))
 1. Les données sont compactées dans mongodb par un traitement map-reduce ([dbmongo](#dbmongo))
@@ -159,6 +165,7 @@ Pour plus de détail sur le traitement des données et les transformations qui l
 
 opensignauxfaibles dispose d'un identifiant lui ouvrant la possibilité de publier des données sur datapi.
 Il lui incombe de fournir à datapi:
+
 - des données détaillées sur les établissements et les entreprises (niveau A)
 - des données synthétiques sur les établissements et les entreprises (niveau B)
 - les listes de détection (niveau A)
@@ -176,6 +183,7 @@ datapi est écrit en go (1.10) et se base sur postgresql (10).
 
 Dans cette infrastructure, datapi est la brique permettant la diffusion contrôlée des données produites dans le projet et sert notamment de back-end pour le signauxfaibles-web.  
 Parmi les fonctionnalités notables:
+
 - stockage arbitraire d'objets JSON
 - gestion dynamique des permissions en lecture/écriture
 - journalisation des requêtes
@@ -185,6 +193,7 @@ Parmi les fonctionnalités notables:
 
 ![workflow](architecture-logicielle/workflow-datapi.png)
 Il est à noter que:
+
 - les insertions et lectures de données sont effectuées au sein de transactions postgres.
 - la prise en compte de l'ajout de données et de politiques de sécurité est intégrée dans le système transactionnel de façon à présenter un comportement synchrone
 - les permissions accordées aux utilisateurs sont véhiculées dans le token JWT et reposent sur la sécurité de keycloak, on les retrouve dans les rôles clients communiqués dans le token.
@@ -199,13 +208,15 @@ Avec l'exemple ci-dessous, nous avons un objet qui pourra-être vu de 3 façons 
 ![stockage](architecture-logicielle/datapi-object.png)
 
 - un utilisateur disposant d'un scope vide verra:
+
 ```javascript
 {
-  raisonSociale: "TEST"
+  raisonSociale: "TEST";
 }
 ```
 
 - un utilisateur disposant du scope [bfc]:
+
 ```javascript
 {
   raisonSociale: "TEST",
@@ -214,6 +225,7 @@ Avec l'exemple ci-dessous, nous avons un objet qui pourra-être vu de 3 façons 
 ```
 
 - un utilisateur disposant du scope [bfc, crp]:
+
 ```javascript
 {
   raisonSociale: "TEST",
@@ -237,15 +249,17 @@ Ce principe seul ne permet pas de supprimer les données de la base de données,
 ### Politiques de sécurité
 
 Une politique de sécurité permet d'intéragir avec les permissions accordées aux utilisateurs. Le périmètre d'application d'une politique de sécurité est définie par une clé d'objet, un scope, un ensemble de buckets (définis par une expression régulière).
-- en ajoutant des badges aux utilisateurs 
-- en ajoutant des badges aux objets 
+
+- en ajoutant des badges aux utilisateurs
+- en ajoutant des badges aux objets
 
 ### Principe de sécurité
 
 - Une ressource comporte des «badges» de sécurité (une liste de tags), les utilisateurs disposent dans leurs attributions de badges.
 - Une ressource n'est disponible à un utilisateur que si il dispose de l'ensemble des badges demandés par la ressource.
 - Des politiques de sécurités permettent de fixer des règles ajoutant des badges aux ressources (renforcement de la contrainte de sécurité) ou aux utilisateurs (promotion)
-- Les politiques de sécurité peuvent s'appliquer à un ensemble d'objets 
+- Les politiques de sécurité peuvent s'appliquer à un ensemble d'objets
+
 ### Dépendances logicielles
 
 - postgresql v10
@@ -260,6 +274,7 @@ Une politique de sécurité permet d'intéragir avec les permissions accordées 
 - https://golang.org/x/crypto/bcrypt
 
 ## signauxfaibles-web
+
 Il s'agit de l'interface utilisée par les agents.
 Cette interface communique avec datapi.
 
@@ -271,15 +286,16 @@ Les tokens JWT (long terme et session) contiennent notamment dans leur chargemen
 ### architecture
 
 signauxfaibles-web est une application vuejs codée en typescript avec les modules suivantes:
+
 - vuetify: environnement graphique
 - vuex: gestion d'un store partagé de variables entre composants
 - axios: client http asynchrone pour traiter les appels à datapi
 - echarts: environnement pour tracer des graphiques
 
-
 ### Dépendance logicielle
 
 Voici la liste des modules yarn nécessaires à la compilation du projet vue.
+
 - @babel/core (7.4.3)
 - axios (0.18.0)
 - core-js (2.6.5)
@@ -318,6 +334,7 @@ Voici la liste des modules yarn nécessaires à la compilation du projet vue.
 La version de mongodb utilisée est la 3.6.
 
 ## keycloak
+
 Il s'agit du produit officiel développé par Red-Hat.
 KeyCloak fournit les services d'authentification pour `goup` et `datapi` en forgeant les JWT des utilisateurs.
 
@@ -336,7 +353,7 @@ Le scope utilisé par datapi sera accessible au travers des rôles clients confi
 La version utilisée est la 10.8.
 Le module hstore du packages contrib est utilisé.
 
-### client TUS 
+### client TUS
 
 Un exemple de client tus est fourni [ici](https://github.com/signaux-faibles/goup/tree/master/goup-client) et permet de voir une implémentation javascript basée sur le client officiel.  
-On trouve toutefois des clients dans de nombreux langages qui permettront aux utilisateurs d'intégrer l'upload de fichier dans leurs plateformes. 
+On trouve toutefois des clients dans de nombreux langages qui permettront aux utilisateurs d'intégrer l'upload de fichier dans leurs plateformes.

--- a/description-donnees.md
+++ b/description-donnees.md
@@ -1,5 +1,4 @@
-Description des données
-=======================
+# Description des données
 
 - [Description des données](#description-des-donn%C3%A9es)
   - [Préambule](#pr%C3%A9ambule)
@@ -34,112 +33,107 @@ Description des données
     - [Données sur le procédures collectives](#donn%C3%A9es-sur-le-proc%C3%A9dures-collectives)
     - [Données sur les CCSF](#donn%C3%A9es-sur-les-ccsf)
 
-Préambule
----------
+## Préambule
 
 Ce dossier technique décrite les données utilisées dans le projet signaux-faibles. Avec l'évolution du projet, celles-ci vont naturellement être amenées à évoluer.
 
 Les données utilisées proviennent de plusieurs sources:
 
--   **Données Sirene** Raison sociale, adresse, code APE, date de création etc.\
--   **Données Altarès** Données de défaillance, permet la définition de l'objectif d'apprentissage
--   **Données DIRECCTE** Autorisations et consommations d'activité partielle, recours à l'intérim, déclaration des mouvements de main-d'oeuvre
--   **Données URSSAF** Montant des cotisations, montant des dettes (part patronale, part ouvrière), demandes de délais de paiement, demandes préalables à l'embauche
--   **Données Banque de France** 6 ratios financiers
--   **Données Diane** Bilans et comptes de résultats. Permet d'enrichir les données financières de la Banque de France
+- **Données Sirene** Raison sociale, adresse, code APE, date de création etc.\
+- **Données Altarès** Données de défaillance, permet la définition de l'objectif d'apprentissage
+- **Données DIRECCTE** Autorisations et consommations d'activité partielle, recours à l'intérim, déclaration des mouvements de main-d'oeuvre
+- **Données URSSAF** Montant des cotisations, montant des dettes (part patronale, part ouvrière), demandes de délais de paiement, demandes préalables à l'embauche
+- **Données Banque de France** 6 ratios financiers
+- **Données Diane** Bilans et comptes de résultats. Permet d'enrichir les données financières de la Banque de France
 
 Les sections ci-dessous détaillent la nature des données importées, et la nature des traitements qui leurs sont appliqués.
 
-Périmètre des données
----------------------
+## Périmètre des données
 
-### Nombre d'établissements  
+### Nombre d'établissements
 
 L'algorithme tourne actuellement sur les données de la
 Bourgogne-Franche-Comté et de Pays de la Loire. L'unité de base est
 l'établissement. Les établissements de moins de 10 salariés ou dont
 l'effectif est inconnu ne sont pas intégrés à l'entraînement de
-l'algorithme. 
+l'algorithme.
 
-Il en résulte un stock de 30085 établissements issues de 22665 entreprises. 
+Il en résulte un stock de 30085 établissements issues de 22665 entreprises.
 Le tableau ci-dessous donne le détail par région (certaines entreprises ont des établissements dans plusieurs régions).
 
-|  Région                  |  Nombre d'établissements                      | Nombre d'entreprises
-| ------------------------ | --------------------------------------------- | --------------------------------
-| Bourgogne-Franche-Comté  | 12347                                         | 9308
-| Pays de la Loire         | 17738                                         | 13807
+| Région                  | Nombre d'établissements | Nombre d'entreprises |
+| ----------------------- | ----------------------- | -------------------- |
+| Bourgogne-Franche-Comté | 12347                   | 9308                 |
+| Pays de la Loire        | 17738                   | 13807                |
 
-Les établissements éventuellement absents de la base sirène (en cas de base sirène obsolète par exemple) sont filtrés en post-traitement. 
+Les établissements éventuellement absents de la base sirène (en cas de base sirène obsolète par exemple) sont filtrés en post-traitement.
 
-### Taux de couverture des données 
+### Taux de couverture des données
 
 TODO
- Rédaction en cours. 
+Rédaction en cours.
 
-Données importées
------------------
+## Données importées
 
 ### Données sirene
 
-|                          |                                               |
-| ------------------------ | --------------------------------------------- |
-| Source        | [Géo-sirene](http://data.cquest.org/geo_sirene/), open source | 
-| Unité | siret |
-| Couverture siret         | Tout établissement actif                     |
+|                          |                                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| Source                   | [Géo-sirene](http://data.cquest.org/geo_sirene/), open source                     |
+| Unité                    | siret                                                                             |
+| Couverture siret         | Tout établissement actif                                                          |
 | Fréquence de mise-à-jour | Source mise à jour quotidiennement mais intégration mensuelle (voire bimensuelle) |
 
-  Le fichier sirene est utilisé comme fichier de référence pour les
-  établissements actifs. On s'en sert pour la raison sociale, le
-  code naf, l'adresse (y compris région et
-  département qui permettent d'ouvrir les droits de consultation sur
-  le terrain). \\
-  \vfill
-  On intègre pour l'algorithme également des données supplémentaires:
-  date de création de l'établissement, présence ou non
-  d'activité saisonnière.
-
+Le fichier sirene est utilisé comme fichier de référence pour les
+établissements actifs. On s'en sert pour la raison sociale, le
+code naf, l'adresse (y compris région et
+département qui permettent d'ouvrir les droits de consultation sur
+le terrain). \\
+\vfill
+On intègre pour l'algorithme également des données supplémentaires:
+date de création de l'établissement, présence ou non
+d'activité saisonnière.
 
 La description détaillée des variables du fichier Sirène est disponible [ici](https://static.data.gouv.fr/resources/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret-page-en-cours-de-construction/20181001-193247/description-fichier-stocketablissement.pdf).
 
-### Données financières de la Banque de France  
+### Données financières de la Banque de France
 
-  Les données financières de la Banque de France couvrent à ce jour uniquement la région Bourgogne Franche Comté. Elles consistent en 6 ratios financiers détaillées ci-dessous. 
+Les données financières de la Banque de France couvrent à ce jour uniquement la région Bourgogne Franche Comté. Elles consistent en 6 ratios financiers détaillées ci-dessous.
 
 |                          |                                               |
 | ------------------------ | --------------------------------------------- |
 | Source                   | Banque de France                              |
-| Unité                    | siren                                         |  
+| Unité                    | siren                                         |
 | Disponibilité            | 2014-2018                                     |
 | Couverture siren         | 70% en 2015                                   |
 | Fréquence de mise-à-jour | annuelle                                      |
 | Délai des données        | Exercice n obtenu en septembre de l'année n+1 |
 
-* __SIREN__ Siren de l'entreprise
+- **SIREN** Siren de l'entreprise
 
-* __ANNEE__ Année de l'exercice
+- **ANNEE** Année de l'exercice
 
-* __ARRETE_BILAN__  Date de clôture de l'exercice. Format mm/jj/aaaa
+- **ARRETE_BILAN** Date de clôture de l'exercice. Format mm/jj/aaaa
 
-* __DENOM__ Raison sociale de l'entreprise 
+- **DENOM** Raison sociale de l'entreprise
 
-* __SECTEUR__ Secteur d'activité
-           
-* __POIDS_FRNG__ Poids du fonds de roulement net global sur le chiffre d'affaire. Exprimé en \%. 
+- **SECTEUR** Secteur d'activité
+- **POIDS_FRNG** Poids du fonds de roulement net global sur le chiffre d'affaire. Exprimé en \%.
 
-* __TX_MARGE__  Taux de marge, rapport de l'excédent brut d'exploitation (EBE) sur la valeur ajoutée. Exprimé en \%. 
-_100*EBE / valeur ajoutee_
+- **TX_MARGE** Taux de marge, rapport de l'excédent brut d'exploitation (EBE) sur la valeur ajoutée. Exprimé en \%.
+  _100\*EBE / valeur ajoutee_
 
-* __DELAI_FRS__ Délai estimé de paiement des fournisseurs. Exprimé en jours. 
-_360 * dettes fournisseurs / achats HT_
+- **DELAI_FRS** Délai estimé de paiement des fournisseurs. Exprimé en jours.
+  _360 \* dettes fournisseurs / achats HT_
 
-* __POIDS_DFISC_SOC__  Poids des dettes fiscales et sociales, par rapport à la valeur ajoutée. Exprimé en \%. 
-_100 * dettes fiscales et sociales / Valeur ajoutee_
+- **POIDS_DFISC_SOC** Poids des dettes fiscales et sociales, par rapport à la valeur ajoutée. Exprimé en \%.
+  _100 \* dettes fiscales et sociales / Valeur ajoutee_
 
-* __POIDS_FIN_CT__ Poids du financement court terme. Exprimé en \%. 
-_100 * concours bancaires courants / chiffre d'affaires HT_
+- **POIDS_FIN_CT** Poids du financement court terme. Exprimé en \%.
+  _100 \* concours bancaires courants / chiffre d'affaires HT_
 
-* __POIDS_FRAIS_FIN__ Poids des frais financiers, sur l'excedent brut d'exploitation corrigé des produits et charges hors exploitation. Exprimé en \%. 
-_100 * frais financiers / (EBE + Produits hors expl. - charges hors expl.)_
+- **POIDS_FRAIS_FIN** Poids des frais financiers, sur l'excedent brut d'exploitation corrigé des produits et charges hors exploitation. Exprimé en \%.
+  _100 \* frais financiers / (EBE + Produits hors expl. - charges hors expl.)_
 
 ### Données financières issues des bilans déposés au greffe de tribunaux de commerce
 
@@ -152,102 +146,102 @@ _100 * frais financiers / (EBE + Produits hors expl. - charges hors expl.)_
 | Fréquence de mise-à-jour | Annuelle                                      |
 | Délai des données        | Exercice n obtenu en septembre de l'année n+1 |
 
-* __Annee__ Année de l'exercice
-* __NomEntreprise__ Raison sociale
-* __NumeroSiren__ Numéro siren
-* __StatutJuridique__  Statut juridique 
-* __ProcedureCollective__ Présence d'une procédure collective en cours 
-* __EffectifConsolide__ Effectif consolidé à l'entreprise
-* __DetteFiscaleEtSociale__  Dette fiscale et sociale
-* __FraisDeRetD__  Frais de Recherche et Développement 
-* __ConcesBrevEtDroitsSim__ Concessions, brevets, et droits similaires
-* __NotePreface__ Note Diane "Préface" entre 0 et 10. 
-* __NombreEtabSecondaire__ Nombre d'établissements secondaires de l'entreprise, en plus du siège. 
-* __NombreFiliale__ Nombre de filiales de l'entreprise. Dans  la  base  de  données des  liens  capitalistiques,  le  concept  de  filiale  ne  fait  aucune  référence  au pourcentage d’appartenance entre le parent et la fille. Dans ce sens, si l'entreprise A est enregistrée comme  ayant  des  intérêts  dans  l'entreprise  B  avec  un  très  petit,  ou  même un  pourcentage  de participation inconnu, l'entreprise B sera considérée filiale de l'entreprise A.  
-* __TailleCompoGroupe__ Nombre d'entreprises dans le groupe (groupe défini par les liens capitalistique d'au moins 50,01\%)
-* __ArreteBilan__ Date d'arrêté du bilan  
-* __NombreMois__ Durée de l'exercice en mois. 
-* __ConcoursBancaireCourant__ Concours bancaires courants. (Pour recalculer les frais financiers court terme de la Banque de France)
+- **Annee** Année de l'exercice
+- **NomEntreprise** Raison sociale
+- **NumeroSiren** Numéro siren
+- **StatutJuridique** Statut juridique
+- **ProcedureCollective** Présence d'une procédure collective en cours
+- **EffectifConsolide** Effectif consolidé à l'entreprise
+- **DetteFiscaleEtSociale** Dette fiscale et sociale
+- **FraisDeRetD** Frais de Recherche et Développement
+- **ConcesBrevEtDroitsSim** Concessions, brevets, et droits similaires
+- **NotePreface** Note Diane "Préface" entre 0 et 10.
+- **NombreEtabSecondaire** Nombre d'établissements secondaires de l'entreprise, en plus du siège.
+- **NombreFiliale** Nombre de filiales de l'entreprise. Dans la base de données des liens capitalistiques, le concept de filiale ne fait aucune référence au pourcentage d’appartenance entre le parent et la fille. Dans ce sens, si l'entreprise A est enregistrée comme ayant des intérêts dans l'entreprise B avec un très petit, ou même un pourcentage de participation inconnu, l'entreprise B sera considérée filiale de l'entreprise A.
+- **TailleCompoGroupe** Nombre d'entreprises dans le groupe (groupe défini par les liens capitalistique d'au moins 50,01\%)
+- **ArreteBilan** Date d'arrêté du bilan
+- **NombreMois** Durée de l'exercice en mois.
+- **ConcoursBancaireCourant** Concours bancaires courants. (Pour recalculer les frais financiers court terme de la Banque de France)
 
 #### Structure et liquidité
 
-* __EquilibreFinancier__ Équilibre financier.
-* __IndependanceFinanciere__ Indépendance financière. 
-* __Endettement__  Endettement. 
-* __AutonomieFinanciere__ Autonomie financière. 
-* __DegreImmoCorporelle__  Degré d'amortissement des immobilisations corporelles
-* __FinancementActifCirculant__ Financement de l'actif circulant net. 
-* __LiquiditeGenerale__ Liquidité générale. 
-* __LiquiditeReduite__ Liquidité réduite. 
+- **EquilibreFinancier** Équilibre financier.
+- **IndependanceFinanciere** Indépendance financière.
+- **Endettement** Endettement.
+- **AutonomieFinanciere** Autonomie financière.
+- **DegreImmoCorporelle** Degré d'amortissement des immobilisations corporelles
+- **FinancementActifCirculant** Financement de l'actif circulant net.
+- **LiquiditeGenerale** Liquidité générale.
+- **LiquiditeReduite** Liquidité réduite.
 
 #### Gestion
 
-* __RotationStocks__ Rotation des stocks (en jours).
-* __CreditClient__ Crédit clients
-* __CreditFournisseur__ Crédit fournisseurs
-* __CAparEffectif__ Chiffre d'affaire par effectif (k€/personne)
-* __TauxInteretFinancier__ Taux d'intérêt financier. 
-* __TauxInteretSurCA__ Intérêts sur chiffre d'affaire. 
-* __EndettementGlobal__ Endettement global
-* __TauxEndettement__ Taux d'endettement. 
-* __CapaciteRemboursement__ Capacité de remboursement. 
-* __CapaciteAutofinancement__ Capacité d'autofinancement.
-* __CouvertureCaFdr__ Couverture du chiffre d'affaire par le fonds de roulement. 
-* __CouvertureCaBesoinFdr__ Couverture du chiffre d'affaire par le besoin en fonds de roulement. 
-* __PoidsBFRExploitation__  Poids des besoins en fonds de roulement d'exploitation. 
-* __Exportation__ Exportation (%)
+- **RotationStocks** Rotation des stocks (en jours).
+- **CreditClient** Crédit clients
+- **CreditFournisseur** Crédit fournisseurs
+- **CAparEffectif** Chiffre d'affaire par effectif (k€/personne)
+- **TauxInteretFinancier** Taux d'intérêt financier.
+- **TauxInteretSurCA** Intérêts sur chiffre d'affaire.
+- **EndettementGlobal** Endettement global
+- **TauxEndettement** Taux d'endettement.
+- **CapaciteRemboursement** Capacité de remboursement.
+- **CapaciteAutofinancement** Capacité d'autofinancement.
+- **CouvertureCaFdr** Couverture du chiffre d'affaire par le fonds de roulement.
+- **CouvertureCaBesoinFdr** Couverture du chiffre d'affaire par le besoin en fonds de roulement.
+- **PoidsBFRExploitation** Poids des besoins en fonds de roulement d'exploitation.
+- **Exportation** Exportation (%)
 
 #### Productivité et rentabilité
 
-* __EfficaciteEconomique__ Efficacité économique (k€/personne)
-* __ProductivitePotentielProduction__ Productivité du potentiel de production
-* __ProductiviteCapitalFinancier__ Productivtié du capital financier.
-* __ProductiviteCapitalInvesti__ Productivité du capital investi. 
-* __TauxDInvestissementProductif__ Taux d'investissement productif. 
-* __RentabiliteEconomique__ Rentabilité économique. 
-* __Performance__ Performance. 
-* __RendementBrutFondsPropres__ Rendement brut des fonds propres.  
-* __RentabiliteNette__  Rentabilité nette. 
-* __RendementCapitauxPropres__ Rendement des capitaux propres. 
-* __RendementRessourcesDurables__  Rendement des ressources durables. 
+- **EfficaciteEconomique** Efficacité économique (k€/personne)
+- **ProductivitePotentielProduction** Productivité du potentiel de production
+- **ProductiviteCapitalFinancier** Productivtié du capital financier.
+- **ProductiviteCapitalInvesti** Productivité du capital investi.
+- **TauxDInvestissementProductif** Taux d'investissement productif.
+- **RentabiliteEconomique** Rentabilité économique.
+- **Performance** Performance.
+- **RendementBrutFondsPropres** Rendement brut des fonds propres.
+- **RentabiliteNette** Rentabilité nette.
+- **RendementCapitauxPropres** Rendement des capitaux propres.
+- **RendementRessourcesDurables** Rendement des ressources durables.
 
 #### Marge et valeur ajoutée
 
-* __TauxMargeCommerciale__ Taux de marge commerciale. 
-* __TauxValeurAjoutee__ Taux de valeur ajoutée. 
-* __PartSalaries__ Part des salariés. 
-* __PartEtat__ Part de l'État.
-* __PartPreteur__   Part des prêteurs.
-* __PartAutofinancement__ Part de l'autofinancement. 
+- **TauxMargeCommerciale** Taux de marge commerciale.
+- **TauxValeurAjoutee** Taux de valeur ajoutée.
+- **PartSalaries** Part des salariés.
+- **PartEtat** Part de l'État.
+- **PartPreteur** Part des prêteurs.
+- **PartAutofinancement** Part de l'autofinancement.
 
 #### Compte de résultat
 
-* __CA__  Chiffre d'affaires
-* __CAExportation__ Chiffre d'affaires à l'exportation
-* __AchatMarchandises__ Achats de marchandises
-* __AchatMatieresPremieres__ Achats de matières premières et autres approvisionnement. 
-* __Production__ Production de l'exercice. 
-* __MargeCommerciale__ Marge commerciale.
-* __Consommation__ Consommation de l'exercice. 
-* __AutresAchatsChargesExternes__ Autres achats et charges externes.
-* __ValeurAjoutee__ Valeur ajoutée.
-* __ChargePersonnel__ Charges de personnel. 
-* __ImpotsTaxes__ Impôts, taxes et versements assimilés.
-* __SubventionsDExploitation__ Subventions d'exploitation. 
-* __ExcedentBrutDExploitation__ Excédent brut d'exploitation.
-* __AutresProduitsChargesReprises__ Autres produits, charges et reprises. 
-* __DotationAmortissement__ Dotation d'exploitation aux amortissements et aux provisions. 
-* __ResultatExpl__ Résultat d'exploitation.
-* __OperationsCommun__ Opérations en commun.
-* __ProduitsFinanciers__ Produits financiers. 
-* __ChargesFinancieres__ Charges financières. 
-* __Interets__ Intérêts et charges assimilées.
-* __ResultatAvantImpot__ Résultat courant avant impôts. 
-* __ProduitExceptionnel__ Produits exceptionnels.
-* __ChargeExceptionnelle__ Charges exceptionnelles. 
-* __ParticipationSalaries__ Participation des salariés aux résultats. 
-* __ImpotBenefice__ Impôts sur les bénéfices et impôts différés. 
-* __BeneficeOuPerte__ Bénéfice ou perte. 
+- **CA** Chiffre d'affaires
+- **CAExportation** Chiffre d'affaires à l'exportation
+- **AchatMarchandises** Achats de marchandises
+- **AchatMatieresPremieres** Achats de matières premières et autres approvisionnement.
+- **Production** Production de l'exercice.
+- **MargeCommerciale** Marge commerciale.
+- **Consommation** Consommation de l'exercice.
+- **AutresAchatsChargesExternes** Autres achats et charges externes.
+- **ValeurAjoutee** Valeur ajoutée.
+- **ChargePersonnel** Charges de personnel.
+- **ImpotsTaxes** Impôts, taxes et versements assimilés.
+- **SubventionsDExploitation** Subventions d'exploitation.
+- **ExcedentBrutDExploitation** Excédent brut d'exploitation.
+- **AutresProduitsChargesReprises** Autres produits, charges et reprises.
+- **DotationAmortissement** Dotation d'exploitation aux amortissements et aux provisions.
+- **ResultatExpl** Résultat d'exploitation.
+- **OperationsCommun** Opérations en commun.
+- **ProduitsFinanciers** Produits financiers.
+- **ChargesFinancieres** Charges financières.
+- **Interets** Intérêts et charges assimilées.
+- **ResultatAvantImpot** Résultat courant avant impôts.
+- **ProduitExceptionnel** Produits exceptionnels.
+- **ChargeExceptionnelle** Charges exceptionnelles.
+- **ParticipationSalaries** Participation des salariés aux résultats.
+- **ImpotBenefice** Impôts sur les bénéfices et impôts différés.
+- **BeneficeOuPerte** Bénéfice ou perte.
 
 ### Données sur l'activité partielle
 
@@ -264,99 +258,102 @@ Deux fichiers: demandes d'activité partielle, et consommations d'activité part
 
 Données communes :
 
-- __ID_DA__ N° de la demande
-- __ETAB_SIRET__ Siret du signataire
-- __ETAB_RSS__ Raison sociale du signataire
-- __DEP__ Département signataire
-- __REG__ Région signataire
-- __ETAB_CODE_INSEE__ Code INSEE commune
-- __ETAB_VILLE__ Ville
-- __CODE_NAF2__ Code NAF 2008
-- __CODE_NAF2_2__ Code NAF sur 88 postes (deux premiers caractères de la variable )CODE_NAF2)
-- __CODE_NAF_TP__ Pseudo indicatrice entreprises  travaux publics vaut :     - TP                si travaux publics     - Autres         sinon
-- __EFF_ENT__ Effectif de l'entreprise
-- __EFF_ETAB__ Effectif de l'établissement
+- **ID_DA** N° de la demande
+- **ETAB_SIRET** Siret du signataire
+- **ETAB_RSS** Raison sociale du signataire
+- **DEP** Département signataire
+- **REG** Région signataire
+- **ETAB_CODE_INSEE** Code INSEE commune
+- **ETAB_VILLE** Ville
+- **CODE_NAF2** Code NAF 2008
+- **CODE_NAF2_2** Code NAF sur 88 postes (deux premiers caractères de la variable )CODE_NAF2)
+- **CODE_NAF_TP** Pseudo indicatrice entreprises travaux publics vaut : - TP si travaux publics - Autres sinon
+- **EFF_ENT** Effectif de l'entreprise
+- **EFF_ETAB** Effectif de l'établissement
 
 #### Données de demandes d'activité partielle
 
-Données spécifiques aux demandes d'activité partielle.   
+Données spécifiques aux demandes d'activité partielle.
 
-- __DATE_STATUT__ Date de création de la demande
+- **DATE_STATUT** Date de création de la demande
 
-- __TX_PC__ Taux de prise en charge
+- **TX_PC** Taux de prise en charge
 
-- __TX_PC_UNEDIC_DARES__ Taux de prise en charge pas l'Unédic
+- **TX_PC_UNEDIC_DARES** Taux de prise en charge pas l'Unédic
 
-- __TX_PC_ETAT_DARES__ Taux de prise en charge par l'Etat
+- **TX_PC_ETAT_DARES** Taux de prise en charge par l'Etat
 
-- __DATE_DEB__ Date de début de la période d'activité partielle, au format JJ/MM/AAAA
+- **DATE_DEB** Date de début de la période d'activité partielle, au format JJ/MM/AAAA
 
-- __DATE_FIN__ Date de fin de la période d'activité partielle, au format JJ/MM/AAAA
+- **DATE_FIN** Date de fin de la période d'activité partielle, au format JJ/MM/AAAA
 
-- __HTA__ Nombre total d'heures autorisées. 
+- **HTA** Nombre total d'heures autorisées.
 
-- __MTA__ Montant total autorisé.
+- **MTA** Montant total autorisé.
 
-- __EFF_AUTO__ Effectifs autorisés. 
+- **EFF_AUTO** Effectifs autorisés.
 
-- __MOTIF_RECOURS_SE__ Cause d'activité partielle. Cf table ci-dessous 
-  
-- __(PERIMETE_EFF) PERIMETRE_AP__ Périmètre du chômage (1 à 4). Cf table ci-dessous
+- **MOTIF_RECOURS_SE** Cause d'activité partielle. Cf table ci-dessous
 
-- __RECOURS_ANTERIEUR__ Recours antérieurs au chômage (1 à 3) :    -  
+- **(PERIMETE_EFF) PERIMETRE_AP** Périmètre du chômage (1 à 4). Cf table ci-dessous
 
-- __AVIS_CE__ Avis du comité d’entreprise
+- **RECOURS_ANTERIEUR** Recours antérieurs au chômage (1 à 3) : -
+
+- **AVIS_CE** Avis du comité d’entreprise
 
 ##### Table des motifs de recours à l'activité partielle
-|   Code | Libellé |
-| ------ | ------- |
-| 1 | Conjoncture économique.  | 
-| 2 | Difficultés d’approvisionnement en matières premières ou en énergie  | 
-| 3 | Sinistre ou intempéries de caractère exceptionnel  | 
-| 4 | Transformation, restructuration ou modernisation des installations et des bâtiments  | 
-| 5 | Autres circonstances exceptionnelles |
+
+| Code | Libellé                                                                             |
+| ---- | ----------------------------------------------------------------------------------- |
+| 1    | Conjoncture économique.                                                             |
+| 2    | Difficultés d’approvisionnement en matières premières ou en énergie                 |
+| 3    | Sinistre ou intempéries de caractère exceptionnel                                   |
+| 4    | Transformation, restructuration ou modernisation des installations et des bâtiments |
+| 5    | Autres circonstances exceptionnelles                                                |
 
 ##### Table des périmètres du chômage.
-|   Code | Libellé |
-| ------ | ------- |
-| 1 | Réduction horaire tout Ets   |
-| 2 | Réduction horaire partie Ets |
-| 3 | Fermeture tempor. Tout Ets   | 
-| 4 | Fermeture tempor. Partie Ets | 
+
+| Code | Libellé                      |
+| ---- | ---------------------------- |
+| 1    | Réduction horaire tout Ets   |
+| 2    | Réduction horaire partie Ets |
+| 3    | Fermeture tempor. Tout Ets   |
+| 4    | Fermeture tempor. Partie Ets |
 
 ##### Table des codes de recours antérieurs au chômage
-|   Code | Libellé |
-| ------ | ------- |
-| 1 | Aucun recours depuis 3 ans                                     | 
-| 2 | Recours au chômage partiel au cours des 3 années précédentes   | 
-| 3 | Non renseigné                                                  | 
+
+| Code | Libellé                                                      |
+| ---- | ------------------------------------------------------------ |
+| 1    | Aucun recours depuis 3 ans                                   |
+| 2    | Recours au chômage partiel au cours des 3 années précédentes |
+| 3    | Non renseigné                                                |
 
 #### Données de consommation d'activité partielle
 
-- __S_HEURE_CONSOM_TOT__	Nombre total d'heures consommées
-- __S_MONTANT_CONSOM_TOT__	Montant total consommé
-- __S_EFF_CONSOM_TOT__	Effectifs consommés
+- **S_HEURE_CONSOM_TOT** Nombre total d'heures consommées
+- **S_MONTANT_CONSOM_TOT** Montant total consommé
+- **S_EFF_CONSOM_TOT** Effectifs consommés
 
-### Table de correspondance entre compte administratif URSSAF et siret 
+### Table de correspondance entre compte administratif URSSAF et siret
 
-|                          |                               |
-| ------------------------ | ----------------------------- |
-| Source                   | URSSAF                        |
-| Couverture               |                TODO           |
-| Fréquence de mise-à-jour | Mensuellement                 |
-| Délai des données        | En temps réel (parfois un mois de retard)       | 
+|                          |                                           |
+| ------------------------ | ----------------------------------------- |
+| Source                   | URSSAF                                    |
+| Couverture               | TODO                                      |
+| Fréquence de mise-à-jour | Mensuellement                             |
+| Délai des données        | En temps réel (parfois un mois de retard) |
 
-- __Numéro de compte externe__ Compte administratif URSSAF
-  
-- __Etat du compte__ Compte ouvert (1) ou fermé (3) ?
+- **Numéro de compte externe** Compte administratif URSSAF
 
-- __Numéro siren__ Numéro Siren de l'entreprise
+- **Etat du compte** Compte ouvert (1) ou fermé (3) ?
 
-- __Numéro d'établissement__ Numéro Siret de l'établissement. Les numéros avec des Lettres sont des sirets provisoires. 
+- **Numéro siren** Numéro Siren de l'entreprise
 
-- __Date de création de l'établissement__  Date de création de l'établissement au format (A)AAMMJJ. (A)AA = AAAA - 1900. 
+- **Numéro d'établissement** Numéro Siret de l'établissement. Les numéros avec des Lettres sont des sirets provisoires.
 
-- __Date de disparition de l'établissement__ Date de disparition de l'établissement au format (A)AAMMJJ (cf date de création)
+- **Date de création de l'établissement** Date de création de l'établissement au format (A)AAMMJJ. (A)AA = AAAA - 1900.
+
+- **Date de disparition de l'établissement** Date de disparition de l'établissement au format (A)AAMMJJ (cf date de création)
 
 ### Données sur l'effectif
 
@@ -367,19 +364,17 @@ Données spécifiques aux demandes d'activité partielle.
 | Fréquence de mise-à-jour | Variable, tous les 3 à 6 mois |
 | Délai des données        | 0 à 6 mois selon mise-à-jour  |
 
+- **Siret** Siret de l'établissement
 
--   **Siret** Siret de l'établissement
+- **Compte** Compte administratif URSSAF
 
--   **Compte** Compte administratif URSSAF
+- **Rais_soc** Raison sociale
 
--   **Rais\_soc** Raison sociale
+- **Ur_emet** Urssaf en charge de la gestion du compte
 
--   **Ur\_emet** Urssaf en charge de la gestion du compte
+- **Dep** Département
 
--   **Dep** Département 
-
--   **effAAAAXY** effectif du mois AAAAXY. AAAA = année. X = trimestre. Y = N° du mois dans le trimestre (ex: 201631 vaut juillet 2016)
-
+- **effAAAAXY** effectif du mois AAAAXY. AAAA = année. X = trimestre. Y = N° du mois dans le trimestre (ex: 201631 vaut juillet 2016)
 
 ### Données sur les cotisations sociales et les débits
 
@@ -395,55 +390,54 @@ Deux fichiers: cotisations, et débits sur les cotisations sociales
 
 #### Fichier sur les cotisations
 
-
-- __Compte__	Compte administratif URSSAF
-- __Periode_debit__	Période en débit.	*A ne pas prendre en compte*
-- __ecn__ Numéro écart négatif.
-- __periode__ Période. Format AAXY, cf ci-dessus l'effectif pour l'explication du format.  
-- __mer__	Cotisation mise en recouvrement, en euros.
-- __enc_direct__	Cotisation encaissée directement, en euros.
-- __cotis_due__	Cotisation due, I euros.	À utiliser pour calculer le montant moyen mensuel du : Somme cotisations dues / nb périodes
-
+- **Compte** Compte administratif URSSAF
+- **Periode_debit** Période en débit. _A ne pas prendre en compte_
+- **ecn** Numéro écart négatif.
+- **periode** Période. Format AAXY, cf ci-dessus l'effectif pour l'explication du format.
+- **mer** Cotisation mise en recouvrement, en euros.
+- **enc_direct** Cotisation encaissée directement, en euros.
+- **cotis_due** Cotisation due, I euros. À utiliser pour calculer le montant moyen mensuel du : Somme cotisations dues / nb périodes
 
 #### Fichiers sur les débits
 
--   **num\_cpte** Compte administratif URSSAF
+- **num_cpte** Compte administratif URSSAF
 
--   **Siren** Siren de l'entreprise
+- **Siren** Siren de l'entreprise
 
--   **Dt\_immat** Date d'immatriculation du compte à l'Urssaf
+- **Dt_immat** Date d'immatriculation du compte à l'Urssaf
 
--   **Etat\_cpte** Code état du compte. Cf la table ci-dessous.
+- **Etat_cpte** Code état du compte. Cf la table ci-dessous.
 
--   **Cd\_pro\_col** Code qui indique si le compte fait l'objet d'une procédure 
-collective. Cf la table ci-dessous. 
+- **Cd_pro_col** Code qui indique si le compte fait l'objet d'une procédure
+  collective. Cf la table ci-dessous.
 
--   **Periode** Période au format AAAAXY. Cf effectif pour l'explication. 
+- **Periode** Période au format AAAAXY. Cf effectif pour l'explication.
 
--   **Num\_Ecn** L'écart négatif (ecn) correspond à une période en débit. Pour 
-une même période, plusieurs débits peuvent être créés. On leur attribue un 
-numéro d'ordre. Par exemple, 101, 201, 301 etc.; ou 101, 102, 201 etc. 
-correspondent respectivement au 1er, 2ème et 3ème ecn de la période considérée. 
+- **Num_Ecn** L'écart négatif (ecn) correspond à une période en débit. Pour
+  une même période, plusieurs débits peuvent être créés. On leur attribue un
+  numéro d'ordre. Par exemple, 101, 201, 301 etc.; ou 101, 102, 201 etc.
+  correspondent respectivement au 1er, 2ème et 3ème ecn de la période considérée.
 
--   **Num\_Hist\_Ecn** Ordre des opérations pour un écart négatif donné. 
+- **Num_Hist_Ecn** Ordre des opérations pour un écart négatif donné.
 
--   **Dt\_trt\_ecn** Date de comptabilisation de l'évènement (mise en 
-recouvrement, paiement etc..). Format (A)AAMMJJ, ou (A)AA correspond à l'année 
-à laquelle a été soustrait 1900. Exemple: 1160318 vaut 18 mars 2016, 
-990612	vaut 12 juin 1999. 
+- **Dt_trt_ecn** Date de comptabilisation de l'évènement (mise en
+  recouvrement, paiement etc..). Format (A)AAMMJJ, ou (A)AA correspond à l'année
+  à laquelle a été soustrait 1900. Exemple: 1160318 vaut 18 mars 2016,
+  990612 vaut 12 juin 1999.
 
--   **Mt\_PO** Montant des débits sur la part ouvrières **en centimes**. Sont 
-exclues les pénalités et les majorations de retard. 
+- **Mt_PO** Montant des débits sur la part ouvrières **en centimes**. Sont
+  exclues les pénalités et les majorations de retard.
 
--   **Mt\_PP** Montant des débits sur la part patronale **en centimes**. Sont 
-exclues les pénalités et les majorations de retard. 
+- **Mt_PP** Montant des débits sur la part patronale **en centimes**. Sont
+  exclues les pénalités et les majorations de retard.
 
--   **Cd\_op\_ecn** Code opération historique de l'écart négatif. Cf table 
-ci-dessous.
+- **Cd_op_ecn** Code opération historique de l'écart négatif. Cf table
+  ci-dessous.
 
--   **Motif\_ecn** Code motif de l'écart négatif. Cf table ci-dessous
+- **Motif_ecn** Code motif de l'écart négatif. Cf table ci-dessous
 
 ##### Codes état du compte
+
 | Code | Description |
 | ---- | ----------- |
 | 1    | Actif       |
@@ -459,8 +453,8 @@ ci-dessous.
 | 2              | Pro col - plan de redressement en cours |
 | 9              | Pro col sans dette à l'Urssaf           |
 
-
 ##### Codes opération historique
+
 | Code | Description                               |
 | ---- | ----------------------------------------- |
 | 1    | Mise en recouvrement                      |
@@ -474,9 +468,8 @@ ci-dessous.
 | 14   | Annulation de remise de majoration retard |
 | 15   | Annulation abandon solde debiteur         |
 
-
-
 ##### Code motif de l'écart négatif
+
 | Code | Description                                                                                |
 | ---- | ------------------------------------------------------------------------------------------ |
 | 0    | Cde motif inconnu                                                                          |
@@ -510,60 +503,60 @@ ci-dessous.
 
 ### Données sur les délais
 
-|                          |                               |
-| ------------------------ | ----------------------------- |
-| Source                   | URSSAF                        |
-| Couverture               | Tous les délais               |
-| Fréquence de mise-à-jour | Mensuellement                 |
-| Délai des données        | Créations en temps réel       | 
+|                          |                         |
+| ------------------------ | ----------------------- |
+| Source                   | URSSAF                  |
+| Couverture               | Tous les délais         |
+| Fréquence de mise-à-jour | Mensuellement           |
+| Délai des données        | Créations en temps réel |
 
-- __Numero de compte externe__ Compte administratif URSSAF
+- **Numero de compte externe** Compte administratif URSSAF
 
-- __Numéro de structure__ Le numéro de structure est l'identifiant d'un dossier contentieux
+- **Numéro de structure** Le numéro de structure est l'identifiant d'un dossier contentieux
 
-- __Date de création__ Date de création du délai. Format aaaa-mm-jj
+- **Date de création** Date de création du délai. Format aaaa-mm-jj
 
-- __Date d'échéance__ Date d'échéance du délai. Format aaaa-mm-jj
+- **Date d'échéance** Date d'échéance du délai. Format aaaa-mm-jj
 
-- __Durée délai__ Durée du délai en jours.
+- **Durée délai** Durée du délai en jours.
 
-- __Dénomination premiére ligne__ Raison sociale de l'établissement.
+- **Dénomination premiére ligne** Raison sociale de l'établissement.
 
-- __Indic 6M__ Délai inférieur ou supérieur à 6 mois? Modalités INF et SUP.
+- **Indic 6M** Délai inférieur ou supérieur à 6 mois? Modalités INF et SUP.
 
-- __année (  Date de création  )__ Année de création du délai.
+- **année ( Date de création )** Année de création du délai.
 
-- __Montant global de l'échéancier__ Montant global de l'échéancier, en euros.
+- **Montant global de l'échéancier** Montant global de l'échéancier, en euros.
 
-- __Numéro de structure__ Champs en double, cf plus haut.
+- **Numéro de structure** Champs en double, cf plus haut.
 
-- __Code externe du stade__
+- **Code externe du stade**
 
-- __Code externe de l'action__
+- **Code externe de l'action**
 
 ### Données sur le procédures collectives
 
-Nous avons utilisé les données fournies par Altares concernant les défaillances en Bourgogne Franche Comté (prestation payante). Comme cette base n'est pas disponible dans toutes les régions, ce seront les données de procédure collective fournies par l'URSSAF qui seront dorénavent utilisées. 
+Nous avons utilisé les données fournies par Altares concernant les défaillances en Bourgogne Franche Comté (prestation payante). Comme cette base n'est pas disponible dans toutes les régions, ce seront les données de procédure collective fournies par l'URSSAF qui seront dorénavent utilisées.
 
-|                          |                                    |
-| ------------------------ | -----------------------------      |
-| Source                   | URSSAF                             |
-| Couverture               | Toutes les procédures collectives  |
-| Fréquence de mise-à-jour | Mensuellement                      |
-| Délai des données        | Créations en temps réel ?          | 
+|                          |                                   |
+| ------------------------ | --------------------------------- |
+| Source                   | URSSAF                            |
+| Couverture               | Toutes les procédures collectives |
+| Fréquence de mise-à-jour | Mensuellement                     |
+| Délai des données        | Créations en temps réel ?         |
 
-- __Siret__ Siret de l'établissement
-- __Siren__ Siren de l'entreprise
-- __Dt_effet__ Date effet de la procédure collective au format JJMMMAAAA, par exemple 24FEB2014
-- __Cat_v2__ ? TODO
-- __Lib_actx_stdx__ Champs double: Nature procédure +  évènement. 
+- **Siret** Siret de l'établissement
+- **Siren** Siren de l'entreprise
+- **Dt_effet** Date effet de la procédure collective au format JJMMMAAAA, par exemple 24FEB2014
+- **Cat_v2** ? TODO
+- **Lib_actx_stdx** Champs double: Nature procédure + évènement.
 
 ### Données sur les CCSF
 
-- __Compte__ Compte administratif URSSAF
-  
-- __Date de traitement__ Date de début de la procédure CCSF au format (A)AAMMJJ, ou (A)AA = AAAA -1900
+- **Compte** Compte administratif URSSAF
 
-- __Code externe du stade__ TODO
+- **Date de traitement** Date de début de la procédure CCSF au format (A)AAMMJJ, ou (A)AA = AAAA -1900
 
-- __Code externe de l'action__ TODO
+- **Code externe du stade** TODO
+
+- **Code externe de l'action** TODO

--- a/interface-graphique.md
+++ b/interface-graphique.md
@@ -1,34 +1,31 @@
-Documentation de l'interface graphique
-======================================
+# Documentation de l'interface graphique
 
-Volet menu 
-----------
+## Volet menu
 
 Le volet menu permet de naviguer entre les différentes fonctionnalités de l'application, et de se déconnecter.
 
-Les fonctionnalités disponibles dans le menu sont: 
+Les fonctionnalités disponibles dans le menu sont:
 
 - L'accès à la liste de détection en cliquant sur l'entrée **Détection**
 - La fenêtre de recherche d'un établissement en particulier, en cliquant sur l'entrée **Consultation**
-- L'entrée **Données** est à ignorer - elle ne concerne que les administrateurs des données. 
+- L'entrée **Données** est à ignorer - elle ne concerne que les administrateurs des données.
 
-Le volet menu s'affiche avec l'icône ![Fleche ouverture](./interface/arrow_show_menu.JPG) en haut à gauche, sur le ruban bleu. Elle se masque avec l'icône ![Fleche fermeture](./interface/arrow_mask_menu.JPG). 
+Le volet menu s'affiche avec l'icône ![Fleche ouverture](./interface/arrow_show_menu.JPG) en haut à gauche, sur le ruban bleu. Elle se masque avec l'icône ![Fleche fermeture](./interface/arrow_mask_menu.JPG).
 
 ![Volet menu](./interface/DEMO4.JPG)
 
-Fenêtre Liste
--------------
+## Fenêtre Liste
 
-La fenêtre liste permet d'explorer les entreprises détectées par l'algorithme. 
+La fenêtre liste permet d'explorer les entreprises détectées par l'algorithme.
 
-La première étape consiste à fixer le périmètre de l'exploration dans le volet filtrage. Dans ce volet figurent plusieurs options de définition du périmètre d'exploration: le choix d'un périmètre géographique, le choix d'un secteur d'activité, le choix d'un effectif minimum, et le filtrage d'entreprises déjà accompagnées, soit par un partenaire, ou dans le contexte d'une procédure collective ou un plan CCSF. 
+La première étape consiste à fixer le périmètre de l'exploration dans le volet filtrage. Dans ce volet figurent plusieurs options de définition du périmètre d'exploration: le choix d'un périmètre géographique, le choix d'un secteur d'activité, le choix d'un effectif minimum, et le filtrage d'entreprises déjà accompagnées, soit par un partenaire, ou dans le contexte d'une procédure collective ou un plan CCSF.
 
 ![Volet filtrage](./interface/volet_filtrage.png)
 
 Une fois ce périmètre fixé, les établissements correspondants apparaissent dans la liste centrale.
 Les établissements sont ordonnées par ordre décroissant d'alerte. Le niveau d'alerte est donné par le pictogramme coloré à gauche. Le symbole rouge avec un point d'exclamation signifie fort niveau d'alerte, le symbole orange avec un point d'interrogation est un niveau d'alerte intermédiaire, et le symbole vert indique l'absence d'alerte.
 
-Quelques données synthétiques complètent la présentation de l'établissement dans la liste: y figurent la raison sociale, le libellé du code naf (activité de l'entreprise). Si le voyant *urssaf* est rouge, alors l'entreprise a connu dans les 6 derniers mois un incident de paiement à l'URSSAF. Si le pictogramme représentant un ouvrier est rouge, alors l'entreprise a recouru à l'activité partielle. Le nombre indiqué à droite du pictogramme représente l'effectif de l'établissement.
+Quelques données synthétiques complètent la présentation de l'établissement dans la liste: y figurent la raison sociale, le libellé du code naf (activité de l'entreprise). Si le voyant _urssaf_ est rouge, alors l'entreprise a connu dans les 6 derniers mois un incident de paiement à l'URSSAF. Si le pictogramme représentant un ouvrier est rouge, alors l'entreprise a recouru à l'activité partielle. Le nombre indiqué à droite du pictogramme représente l'effectif de l'établissement.
 
 À droite figurent le chiffre d'affaire et le résultat d'exploitation. Une flèche indique les variations de plus de 5% du chiffre d'affaire (augmentation ou diminution selon le sens de la flèche).
 Le résultat d'exploitation est rouge lorsqu'il est négatif.
@@ -37,25 +34,22 @@ Le résultat d'exploitation est rouge lorsqu'il est négatif.
 
 Pour inspecter un établissement plus en détail, il suffit de cliquer n'importe où sur la ligne de celui-ci.
 
-Fiche établissement
----------------------
+## Fiche établissement
 
-La fenêtre établissement donne une information plus détaillée de l'établissement en question. Le niveau de détail et le contenu de cette page dépend du niveau d'habilitation de l'utilisateur. 
+La fenêtre établissement donne une information plus détaillée de l'établissement en question. Le niveau de détail et le contenu de cette page dépend du niveau d'habilitation de l'utilisateur.
 
-On y trouve la raison sociale, le siret, le secteur d'activité de l'entreprise, sa localisation, des informations sur mes variations d'effectif et le recours à l'activité partielle, des informations sur les cotisations URSSAF, d'éventuels débits ou délais de paiements octroyés par l'URSSAF, des informations financières sur plusieurs exercices consécutifs. 
+On y trouve la raison sociale, le siret, le secteur d'activité de l'entreprise, sa localisation, des informations sur mes variations d'effectif et le recours à l'activité partielle, des informations sur les cotisations URSSAF, d'éventuels débits ou délais de paiements octroyés par l'URSSAF, des informations financières sur plusieurs exercices consécutifs.
 
 ![Fiche établissement](./interface/fiche_etablissement.jpg)
 
-Rechercher un établissement
-----------------------------
+## Rechercher un établissement
 
-Depuis le menu, on peut chercher un établissement sur la page **Consultation** et accéder à sa fiche. 
+Depuis le menu, on peut chercher un établissement sur la page **Consultation** et accéder à sa fiche.
 
 ![Page consultation](./interface/DEMO1.JPG)
 
-Il suffit de rentrer le début de sa raison sociale, ou le début du code SIRET de l'établissement, puis de sélectionner l'établissement en question dans la liste déroulante, pour pouvoir accéder à la fiche établissement correspondante. 
+Il suffit de rentrer le début de sa raison sociale, ou le début du code SIRET de l'établissement, puis de sélectionner l'établissement en question dans la liste déroulante, pour pouvoir accéder à la fiche établissement correspondante.
 
-F.A.Q.
-------
+## F.A.Q.
 
 Cette section sera complétée au fur et à mesure des questions des utilisateurs.

--- a/nota_diane.md
+++ b/nota_diane.md
@@ -1,8 +1,8 @@
-* Faire une liste triée des sirets déja connus
-* Changer la liste des départements à extraire et le chemin d'accès vers la liste triée
-* Faire tourner le script sur le fichier effectif
-* Dans Diane (compte Brocard): nouvelles variables -> créer nouvelle variables (option identifiant entreprise)
-* Convertir le fichier csv enxlsx (veiller à mettre le siret en colonne texte) et changer le nom en fonction du nom dans l'interface CF00005
-* Aller dans "entreprises avec données importées"
-* Changer les colonnes (mettre à jour les années si besoin: export+ macro vim + import)
-* Extraire en 42 étapes
+- Faire une liste triée des sirets déja connus
+- Changer la liste des départements à extraire et le chemin d'accès vers la liste triée
+- Faire tourner le script sur le fichier effectif
+- Dans Diane (compte Brocard): nouvelles variables -> créer nouvelle variables (option identifiant entreprise)
+- Convertir le fichier csv enxlsx (veiller à mettre le siret en colonne texte) et changer le nom en fonction du nom dans l'interface CF00005
+- Aller dans "entreprises avec données importées"
+- Changer les colonnes (mettre à jour les années si besoin: export+ macro vim + import)
+- Extraire en 42 étapes

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -83,7 +83,7 @@ L'import est le processus qui consiste à récupérer les fichiers bruts, c'est-
 
 L'intégration se fait par "batch". Chaque batch est défini dans la collection "Admin" de la base MongoDB par un objet de la forme suivante:
 
-```json
+```js
 {
   "_id": {
     "key": "1802", // Doit être en ordre alphabétique

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -1,65 +1,60 @@
-Processus traitement des données
-================================
+# Processus traitement des données
 
 Table of content here TODO
 
-Préambule
----------
+## Préambule
 
-Dans cette partie, nous explorons comment sont stockées et transformées les données à  partir des fichiers bruts.
+Dans cette partie, nous explorons comment sont stockées et transformées les données à partir des fichiers bruts.
 
-Vue d'ensemble des canaux de transformation des données
--------------------------------------------------------
+## Vue d'ensemble des canaux de transformation des données
 
-La base de donneé MongoDB dans laquelle les données sont intégrées est définie dans le fichier config.toml. 
+La base de donneé MongoDB dans laquelle les données sont intégrées est définie dans le fichier config.toml.
 
-Le schéma ci-dessous montre les différentes étapes de transformation des données. 
+Le schéma ci-dessous montre les différentes étapes de transformation des données.
 
 ![Schéma vue d'ensemble traitement](./traitement-donnees/Vue_densemble_traitement.png)
 
+L'intégration et le stockage de données se fait par mises-à-jours successives, qu'on appelle "batch". Le parcours de la données est alors à chaque fois identique.
 
-L'intégration et le stockage de données se fait par mises-à-jours successives, qu'on appelle "batch". Le parcours de la données est alors à chaque fois identique.  
+**1- Import**
 
-  __1- Import__
+Ce parcours est représenté avec des flêches pleines. Toutes les nouvelles données sont d'abord importées dans une collection ImportedData à l'aide de fonctions golang spécifiques à chaque type de fichier. La collection Admin définit quels sont les fichiers à intégrer pour chaque "batch". Le processus d'intégration et les potentielles erreurs d'ouverture de fichier, de lecture, ou de conversion sont logués dans la collection Journal.
 
-Ce parcours est représenté avec des flêches pleines. Toutes les nouvelles données sont d'abord importées dans une collection ImportedData à l'aide de fonctions golang spécifiques à chaque type de fichier. La collection Admin définit quels sont les fichiers à intégrer pour chaque "batch". Le processus d'intégration et les potentielles erreurs d'ouverture de fichier, de lecture, ou de conversion sont logués dans la collection Journal. 
+Les données ainsi intégrées proviennent de fichiers de différents formats: .csv, .excel, .sas7dbat etc. La façon dont les données sont mises-à-jour peut également être différente, avec des fichiers qui annulent et remplacent, qu'on qualifiera de "fichiers stocks", et des fichiers qui viennent amender, qu'on qualifiera de "fichiers flux". Ceci est configuré dans la collection admin.
 
-Les données ainsi intégrées proviennent de fichiers de différents formats: .csv, .excel, .sas7dbat etc. La façon dont les données sont mises-à-jour peut également être différente, avec des fichiers qui annulent et remplacent, qu'on qualifiera de "fichiers stocks", et des fichiers qui viennent amender, qu'on qualifiera de "fichiers flux". Ceci est configuré dans la collection admin. 
+**2- Compactage**
 
-__2- Compactage__
-
-Une fois le batch importées dans la collection ImportedData, elles vont venir compléter la collection RawData, qui concentrent les informations autour de l'établissement (identifiant: numéro siret) ou de l'entreprise (identifiant: numéro siren). C'est une opération de MapReduce qui est utilisé à cet effet. 
+Une fois le batch importées dans la collection ImportedData, elles vont venir compléter la collection RawData, qui concentrent les informations autour de l'établissement (identifiant: numéro siret) ou de l'entreprise (identifiant: numéro siren). C'est une opération de MapReduce qui est utilisé à cet effet.
 
 Le processus de compactage consiste à attribuer à chaque objet les nouvelles données qui le concernent, vérifier si ces donneés étaient déjà connues (auquel cas l'objet n'est pas modifié), si les données amendent les informations connues, ou si des informations connues, qui ne seraient plus d'actualité, sont à supprimer.
 
 La collection RawData conserve l'historique des modifications successives à chaque batch, ce qui rend possible de rétablir chaque objet dans son état après l'intégration de n'importe quel batch.
 
-Si le compactage réussit, la collection ImportedData est purgée. 
+Si le compactage réussit, la collection ImportedData est purgée.
 
-__3- Calcul des variables__
+**3- Calcul des variables**
 
-Enfin, les données ainsi stockées vont servir au calcul des variables qui alimenteront l'algorithme, stockées dans la collection Features. C'est à nouveau une opération de MapReduce qui permet de prendre en compte l'historique des données conservées dans RawData et calculer les variables pertinentes. 
+Enfin, les données ainsi stockées vont servir au calcul des variables qui alimenteront l'algorithme, stockées dans la collection Features. C'est à nouveau une opération de MapReduce qui permet de prendre en compte l'historique des données conservées dans RawData et calculer les variables pertinentes.
 
 ## Workflow classique
 
-Le workflow classique d'intégration consiste à: 
+Le workflow classique d'intégration consiste à:
 
-* Lancer l'API: `go build && ./dbmongo`
+- Lancer l'API: `go build && ./dbmongo`
 
-* Définir l'objet batch dans la collection Admin, avec les chemins d'accès des fichiers à intégrer
-* Apeler la fonction d'intégration process, qui va se charger de l'import, du compactage et du calcul de variables avec les options idoines:
+- Définir l'objet batch dans la collection Admin, avec les chemins d'accès des fichiers à intégrer
+- Apeler la fonction d'intégration process, qui va se charger de l'import, du compactage et du calcul de variables avec les options idoines:
 
 ```
   http :3000/api/admin/batch/process batches:='["1904"]'
 ```
 
-Toutes ces étapes seront détaillées par la suite. 
+Toutes ces étapes seront détaillées par la suite.
 
 Il est à noter qu'aucun travail d'UX n'a encore été mené, et donc peu d'information sur les travaux en cours peuvent être donnés à l'utilisateur.
 Au cours de l'import, un log des début et des fin d'intégration de fichiers et de types de fichiers sont loggés dans la collection Journal.
 Pendant le compactage et le calcul des variables, le log de mongodb peut être consulté.
-Entre ces traitements, une façon de s'assurer que le processus tourne est de vérifier qu'il n'y a pas d'erreur golang, et que mongodb travaille, par exemple avec la commande *top*. 
-
+Entre ces traitements, une façon de s'assurer que le processus tourne est de vérifier qu'il n'y a pas d'erreur golang, et que mongodb travaille, par exemple avec la commande _top_.
 
 ## L'API servie par Golang
 
@@ -72,139 +67,132 @@ go build && ./dbmongo
 
 L'API est alors lancée sur localhost, par défaut sur le port 3000 (le port peut-être modifié dans le fichier `./dbmongo/config.toml`)
 
-Cette API est documentée par swagger, et est alors accessible sur `localhost:3000/swagger/index.html`. 
+Cette API est documentée par swagger, et est alors accessible sur `localhost:3000/swagger/index.html`.
 
-Certaines des commandes seront plus amplement détaillées dans ce qui suit. 
+Certaines des commandes seront plus amplement détaillées dans ce qui suit.
 
 ## La base de données MongoDB
 
 Le stockage des données se fait dans une base de données "objet", notre choix s'est porté sur MongoDB. L'adresse et le port de la base de données est spécifiée dans `./dbmongo/config.toml`.
 
-Les différentes collections utilisées seront détaillées par la suite. 
+Les différentes collections utilisées seront détaillées par la suite.
 
 ## Spécificités de l'import
 
-L'import est le processus qui consiste à récupérer les fichiers bruts, c'est-à-dire dans le format dans lequel il a été transmis, de le lire, d'en extraire les informations pertinentes et de les intégrer dans la base de données mongodb. 
+L'import est le processus qui consiste à récupérer les fichiers bruts, c'est-à-dire dans le format dans lequel il a été transmis, de le lire, d'en extraire les informations pertinentes et de les intégrer dans la base de données mongodb.
 
 L'intégration se fait par "batch". Chaque batch est défini dans la collection "Admin" de la base MongoDB par un objet de la forme suivante:
 
 ```json
-{ 
-    "_id" : {
-        "key" : "1802", // Doit être en ordre alphabétique
-        "type" : "batch"
-    }, 
-     "files" : {
-        "admin_urssaf" : [
-            "/1802/admin_urssaf/admin_urssaf.csv"
-        ], 
-        "autre_type": [
-          "Chemin/daccès/1.xlsx",
-          "Chemin/daccès/2.xlsx"
-        ]
-    }, 
-    "readonly" : true, 
-    "complete_types" : [
-        "apconso", 
-        "apdemande", 
-        "effectif"
-    ], 
-    "param" : {
-        "date_debut" : ISODate("2014-01-01T00:00:00.000+0000"), 
-        "date_fin" : ISODate("2018-12-01T00:00:00.000+0000"), 
-        "date_fin_effectif" : ISODate("2018-06-01T00:00:00.000+0000")
-    }
+{
+  "_id": {
+    "key": "1802", // Doit être en ordre alphabétique
+    "type": "batch"
+  },
+  "files": {
+    "admin_urssaf": ["/1802/admin_urssaf/admin_urssaf.csv"],
+    "autre_type": ["Chemin/daccès/1.xlsx", "Chemin/daccès/2.xlsx"]
+  },
+  "readonly": true,
+  "complete_types": ["apconso", "apdemande", "effectif"],
+  "param": {
+    "date_debut": ISODate("2014-01-01T00:00:00.000+0000"),
+    "date_fin": ISODate("2018-12-01T00:00:00.000+0000"),
+    "date_fin_effectif": ISODate("2018-06-01T00:00:00.000+0000")
+  }
 }
 ```
 
-Le champ `_id` permet de spécifier qu'il s'agit un objet batch, et lui donne un nom, sous forme de clé. Attention, les batchs seront traités par ordre alphabétique. Par convention, les batchs sont intitulés "AAMM", en fonction de la période à laquelle ils sont intégrés, et peuvent être découpés en plusieurs parties nommée "AAMM_partX" ou X est incrémenté à chaque partie. Le champ `key` doit être unique. 
+Le champ `_id` permet de spécifier qu'il s'agit un objet batch, et lui donne un nom, sous forme de clé. Attention, les batchs seront traités par ordre alphabétique. Par convention, les batchs sont intitulés "AAMM", en fonction de la période à laquelle ils sont intégrés, et peuvent être découpés en plusieurs parties nommée "AAMM_partX" ou X est incrémenté à chaque partie. Le champ `key` doit être unique.
 
-Le champs `files` associe à un type un ou plusieurs fichiers. Les types définissent quel script d'intégration sera utilisé pour intégrer les fichiers mentionnés. Les chemins d'accès sont spécifiées avec comme racine le dossier défini dans config.toml avec le champs `APP_DATA`, sans `.` préalable au début du chemin d'accès. Une liste des types et des fichiers associés est donné dans le tableau TODO. 
+Le champs `files` associe à un type un ou plusieurs fichiers. Les types définissent quel script d'intégration sera utilisé pour intégrer les fichiers mentionnés. Les chemins d'accès sont spécifiées avec comme racine le dossier défini dans config.toml avec le champs `APP_DATA`, sans `.` préalable au début du chemin d'accès. Une liste des types et des fichiers associés est donné dans le tableau TODO.
 
 Le champ `readonly` permet d'empêcher la modification de l'objet par l'API, une fois les traitements lancés, pour assurer l'adéquation entre l'objet dans Admin et les objets importés.
 
-Le champ `complete_types` est utile pour le comportement de compactage (cf paragraphe suivant). Les fichiers des types complets annulent et remplacent toutes les données précédemment importées pour ce type, alors que les autres viennent compléter les données passées. 
+Le champ `complete_types` est utile pour le comportement de compactage (cf paragraphe suivant). Les fichiers des types complets annulent et remplacent toutes les données précédemment importées pour ce type, alors que les autres viennent compléter les données passées.
 
-Le champ `param` est utile pour le calcul des variables (cf le paragraphe à ce sujet).  Il définit l'étendu des périodes à traiter et la dernière période pour laquelle les données d'effectif sont disponibles. 
+Le champ `param` est utile pour le calcul des variables (cf le paragraphe à ce sujet). Il définit l'étendu des périodes à traiter et la dernière période pour laquelle les données d'effectif sont disponibles.
 
-Attention, il n'y a à ce jour pas de processus de validation des chemins d'accès. Un chemin d'accès erroné provoquera une erreur dans l'import des données. 
+Attention, il n'y a à ce jour pas de processus de validation des chemins d'accès. Un chemin d'accès erroné provoquera une erreur dans l'import des données.
 
-Les types définis sont accessibles via: 
+Les types définis sont accessibles via:
+
 ```
 http :3000/api/admin/types
 ```
 
-| Parser              | type          | extension    | Scope
-| ------------        | ------------- | ---------    | --------
-| urssaf.Parser       | admin_urssaf  | csv          | table etablissement <-> compte Urssaf
-|                     | cotisation    | csv          | compte Urssaf
-|                     | procol        | csv          | etablissement
-|                     | debit         | csv          | compte Urssaf
-|                     | effectif      | csv          | etablissement
-|                     | delai         | csv          | compte Urssaf
-|                     | dpae          | csv          | compte Urssaf
-|                     | ccsf          | csv          | compte Urssaf
-|                     | dmmo          | xlsx         | compte Urssaf
-| apartconso.Parser   | apconso       | xlsx         | etablissement
-| apartdemande.Parser | apdemande     | xlsx         | etablissement
-| altares.Parser      | altares       | csv          | etablissement
-| bdf.Parser          | bdf           | csv          | entreprise
-| interim.Parser      | interim       | sas7dbat     | etablissement
-| sirene.Parser       | sirene        | csv          | etablissement
-| diane.Parser        | diane         | script + csv | entreprise
+| Parser              | type         | extension    | Scope                                 |
+| ------------------- | ------------ | ------------ | ------------------------------------- |
+| urssaf.Parser       | admin_urssaf | csv          | table etablissement <-> compte Urssaf |
+|                     | cotisation   | csv          | compte Urssaf                         |
+|                     | procol       | csv          | etablissement                         |
+|                     | debit        | csv          | compte Urssaf                         |
+|                     | effectif     | csv          | etablissement                         |
+|                     | delai        | csv          | compte Urssaf                         |
+|                     | dpae         | csv          | compte Urssaf                         |
+|                     | ccsf         | csv          | compte Urssaf                         |
+|                     | dmmo         | xlsx         | compte Urssaf                         |
+| apartconso.Parser   | apconso      | xlsx         | etablissement                         |
+| apartdemande.Parser | apdemande    | xlsx         | etablissement                         |
+| altares.Parser      | altares      | csv          | etablissement                         |
+| bdf.Parser          | bdf          | csv          | entreprise                            |
+| interim.Parser      | interim      | sas7dbat     | etablissement                         |
+| sirene.Parser       | sirene       | csv          | etablissement                         |
+| diane.Parser        | diane        | script + csv | entreprise                            |
 
-Les fichiers en provenance des urssaf ont été regroupées dans un parser spécifique du fait de leur dépendance à la table de correspondance entre comptes Urssaf et codes Siret, qui est ainsi chargée une seule fois en mémoire.  
+Les fichiers en provenance des urssaf ont été regroupées dans un parser spécifique du fait de leur dépendance à la table de correspondance entre comptes Urssaf et codes Siret, qui est ainsi chargée une seule fois en mémoire.
 
-L'import est lancé avec la requête: 
+L'import est lancé avec la requête:
+
 ```
 http :3000/api/data/import [options]
 # Par exemple
 http :3000/api/data/import batch="1904" parsers:='["urssaf", "diane"]'
 ```
 
-Le paramètre obligatoire `batch` indique la clé du batch à importer. Le paramètre optionnel `parsers`, qui est entré sous forme de tableau, permet de sélectionner les parsers à faire tourner. Par défaut, tous les parsers du batch sont lancés, cette option permet de corriger un type de fichier en particulier en cas d'erreur pendant l'intégration. 
+Le paramètre obligatoire `batch` indique la clé du batch à importer. Le paramètre optionnel `parsers`, qui est entré sous forme de tableau, permet de sélectionner les parsers à faire tourner. Par défaut, tous les parsers du batch sont lancés, cette option permet de corriger un type de fichier en particulier en cas d'erreur pendant l'intégration.
 
 ## Spécificités du compactage
 
-Le compactage est la procédure de fusion des nouvelles données importées avec les données importées dans des batchs antérieurs. 
+Le compactage est la procédure de fusion des nouvelles données importées avec les données importées dans des batchs antérieurs.
 
-Le paramètre `complete_types` dans la collection Admin définit la manière dont les nouvelles données se comportent par rapport au données existantes. Si le type est "complet", ou en "stock" (c'est-à-dire que chaque nouveau fichier reprèsente le stock à la période courante) alors les nouvelles données remplacent intégralement les dernières. Attention, si aucun fichier n'est intégré et que le type est considéré comme complet, alors toutes les données passées seront ignorées. Les types qui ne sont pas complets sont dits de "flux" (c'est-à-dire que chaque nouveau fichier vient compléter les fichiers des périodes précédentes), et les données précédentes sont conservées. 
+Le paramètre `complete_types` dans la collection Admin définit la manière dont les nouvelles données se comportent par rapport au données existantes. Si le type est "complet", ou en "stock" (c'est-à-dire que chaque nouveau fichier reprèsente le stock à la période courante) alors les nouvelles données remplacent intégralement les dernières. Attention, si aucun fichier n'est intégré et que le type est considéré comme complet, alors toutes les données passées seront ignorées. Les types qui ne sont pas complets sont dits de "flux" (c'est-à-dire que chaque nouveau fichier vient compléter les fichiers des périodes précédentes), et les données précédentes sont conservées.
 
-Par exemple, si certaines données n'ont pas changé d'une période sur l'autre, alors il n'est pas nécessaire de réintégrer de fichier mais simplement de veiller que le type n'est pas listé parmi les `complete_types`. 
+Par exemple, si certaines données n'ont pas changé d'une période sur l'autre, alors il n'est pas nécessaire de réintégrer de fichier mais simplement de veiller que le type n'est pas listé parmi les `complete_types`.
 
 Le compactage se lance avec la commande suivante:
 
 ```
 http :3000/api/data/compact [options]
 # Par exemple
-http :3000/api/data/compact batch="1804" 
+http :3000/api/data/compact batch="1804"
 ```
 
-
-## Spécificités des calculs de variables 
+## Spécificités des calculs de variables
 
 TODO
 `param` dans la collection Admin
 
-Le calcul des variables est lancé via la requête: 
+Le calcul des variables est lancé via la requête:
+
 ```
 http :3000/api/data/reduce [options]
-# Par exemple 
+# Par exemple
 http :3000/api/data/reduce batch="1904" key="01234567891011" features="algo2"
 ```
 
-Les paramètres optionnels `batch` et `features` spécifient respectivement la clé du dernier batch intégré et le type de calcul à mener. Actuellement, uniquement "algo2" est fonctionnel. 
-Le paramètre facultatif `key` permet de ne faire tourner les calculs que pour un siret particulier, essentiellement pour des raisons de debugging. 
+Les paramètres optionnels `batch` et `features` spécifient respectivement la clé du dernier batch intégré et le type de calcul à mener. Actuellement, uniquement "algo2" est fonctionnel.
+Le paramètre facultatif `key` permet de ne faire tourner les calculs que pour un siret particulier, essentiellement pour des raisons de debugging.
 Les données sont alors importées dans la collection `Features_debug` plutôt que dans la collection `Features`.
 
 ## La commande batch/process
 
-La commande **batch/process** permet de lancer successivement l'import, le compactage et les calculs des variables pour un batch donné avec les options par défaut, en une seule commande. 
+La commande **batch/process** permet de lancer successivement l'import, le compactage et les calculs des variables pour un batch donné avec les options par défaut, en une seule commande.
 
 Cette commande accepte plusieurs batches, auquel cas elle intégrera ces batches successivement.
 
 ```
 http :3000/api/admin/batch/process [options]
-http :3000/api/admin/batch/process batches:='["1904"]' 
+http :3000/api/admin/batch/process batches:='["1904"]'
 http :3000/api/admin/batch/process batches:='["1904", "1905"]'
 ```

--- a/supervision.md
+++ b/supervision.md
@@ -14,7 +14,7 @@ Cet aspect est utile pour effectuer un suivi au long cours de l'évolution de la
 
 Ces outils doivent permettre la mise en place de sondes automatiques pour faire remonter des alertes lorsque les dispositifs ne sont plus à même de fournir le service aux utilisateurs.
 
-## Solution envisagée
+## Solution envisagée
 
 ### netdata
 

--- a/supervision.md
+++ b/supervision.md
@@ -1,22 +1,29 @@
 # Supervision de la plateforme
 
 ## Préambule
+
 Cette partie en est à ses balbultiements, toutefois il semble opportun de mentionner les options techniques investiguées.
 
 ## Objectif
+
 ### Monitoring des performances
+
 Cet aspect est utile pour effectuer un suivi au long cours de l'évolution de la demande en ressources de la solution signaux-faibles, mais également pour réaliser les tests de montée en charge.
 
 ### Monitoring de la disponibilité
+
 Ces outils doivent permettre la mise en place de sondes automatiques pour faire remonter des alertes lorsque les dispositifs ne sont plus à même de fournir le service aux utilisateurs.
 
 ## Solution envisagée
+
 ### netdata
+
 NetData est spécialisé dans la prise d'information sur le fonctionnement du matériel et les indicateurs de performance des services. Il offre par ailleurs une faible emprunte mémoire et cpu ce qui en fait un candidat de choix.
 
 ### grafana
+
 Grafana est une solution spécialisée dans l'analyse de série temporelle et la fourniture d'indicateurs au travers de tableaux de bord hautement paramétrables.
 
 ### graphite
-Graphite permet de collecter les métriques et de les stocker pour une analyse long terme, son intégration avec Grafana et Netdata est une solution relativement répandue et populaire.
 
+Graphite permet de collecter les métriques et de les stocker pour une analyse long terme, son intégration avec Grafana et Netdata est une solution relativement répandue et populaire.


### PR DESCRIPTION
## Reason for PR

I noticed that a heading was not formatted as expected in README.md, and then, that the formatting was not homogeneous. (e.g. trailing whitespace, lack of line breaks, etc...)

## Proposed changes

I propose to homogenize the formatting using `prettier`, a node/npm module that can reformat many kinds of files, including Markdown files.

And to add a `Makefile` to make sure that anybody is aware of the existence of this script, and of how to run it.

## How to test

Run:
- `$ make`
- `$ make formatting`

## Proposed next steps

- Idea: add a [doctoc](https://www.npmjs.com/package/doctoc) script to auto-generate the tables of content ^^

What do you think?
