### PR TITLE
feat: Génération automatique des tables des matières + GitHub check

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,0 +1,25 @@
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: CI Checks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Run formatting scripts
+        run: make
+      - name: Expect empty diff
+        run: exit $(git diff | wc -l)
+        # Return a non-zero error code if any output file has changed

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .*
 !.gitignore
+!.github
 archive

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-.DEFAULT_GOAL := help
+.DEFAULT_GOAL := all
 
 formatting: ## Fix the formatting of md files
 	@npx prettier --write .
+
+doctoc: ## Update the tables of contents
+	@npx doctoc processus-traitement-donnees.md
+
+all: doctoc formatting
 
 help: ## This help.
 	@echo 'Available targets:'
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-.PHONY: help formatting
+.PHONY: formatting doctoc help

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -3,8 +3,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-**Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
-
 - [Préambule](#pr%C3%A9ambule)
 - [Vue d'ensemble des canaux de transformation des données](#vue-densemble-des-canaux-de-transformation-des-donn%C3%A9es)
 - [Workflow classique](#workflow-classique)

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -1,6 +1,21 @@
 # Processus traitement des données
 
-Table of content here TODO
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Processus traitement des données](#processus-traitement-des-donn%C3%A9es)
+  - [Préambule](#pr%C3%A9ambule)
+  - [Vue d'ensemble des canaux de transformation des données](#vue-densemble-des-canaux-de-transformation-des-donn%C3%A9es)
+  - [Workflow classique](#workflow-classique)
+  - [L'API servie par Golang](#lapi-servie-par-golang)
+  - [La base de données MongoDB](#la-base-de-donn%C3%A9es-mongodb)
+  - [Spécificités de l'import](#sp%C3%A9cificit%C3%A9s-de-limport)
+  - [Spécificités du compactage](#sp%C3%A9cificit%C3%A9s-du-compactage)
+  - [Spécificités des calculs de variables](#sp%C3%A9cificit%C3%A9s-des-calculs-de-variables)
+  - [La commande batch/process](#la-commande-batchprocess)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Préambule
 

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -2,18 +2,18 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Processus traitement des données](#processus-traitement-des-donn%C3%A9es)
-  - [Préambule](#pr%C3%A9ambule)
-  - [Vue d'ensemble des canaux de transformation des données](#vue-densemble-des-canaux-de-transformation-des-donn%C3%A9es)
-  - [Workflow classique](#workflow-classique)
-  - [L'API servie par Golang](#lapi-servie-par-golang)
-  - [La base de données MongoDB](#la-base-de-donn%C3%A9es-mongodb)
-  - [Spécificités de l'import](#sp%C3%A9cificit%C3%A9s-de-limport)
-  - [Spécificités du compactage](#sp%C3%A9cificit%C3%A9s-du-compactage)
-  - [Spécificités des calculs de variables](#sp%C3%A9cificit%C3%A9s-des-calculs-de-variables)
-  - [La commande batch/process](#la-commande-batchprocess)
+**Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
+
+- [Préambule](#pr%C3%A9ambule)
+- [Vue d'ensemble des canaux de transformation des données](#vue-densemble-des-canaux-de-transformation-des-donn%C3%A9es)
+- [Workflow classique](#workflow-classique)
+- [L'API servie par Golang](#lapi-servie-par-golang)
+- [La base de données MongoDB](#la-base-de-donn%C3%A9es-mongodb)
+- [Spécificités de l'import](#sp%C3%A9cificit%C3%A9s-de-limport)
+- [Spécificités du compactage](#sp%C3%A9cificit%C3%A9s-du-compactage)
+- [Spécificités des calculs de variables](#sp%C3%A9cificit%C3%A9s-des-calculs-de-variables)
+- [La commande batch/process](#la-commande-batchprocess)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -24,7 +24,6 @@ Dans cette partie, nous explorons comment sont stockées et transformées les do
 Note: Vous pouvez installer la commande `http` utilisée dans les exemples de cette page à partir de [HTTPie – command line HTTP client](https://httpie.org/).
 
 ## Vue d'ensemble des canaux de transformation des données
-
 
 La base de donneé MongoDB dans laquelle les données sont intégrées est définie dans le fichier config.toml.
 
@@ -125,7 +124,6 @@ Le champ `_id` permet de spécifier qu'il s'agit un objet batch, et lui donne un
 
 Le champs `files` associe à un type un ou plusieurs fichiers. Les types définissent quel script d'intégration sera utilisé pour intégrer les fichiers mentionnés. Les chemins d'accès sont spécifiées avec comme racine le dossier défini dans config.toml avec le champs `APP_DATA`, sans `.` préalable au début du chemin d'accès. Une liste des types et des fichiers associés est donné dans le tableau, plus bas.
 
-
 Le champ `readonly` permet d'empêcher la modification de l'objet par l'API, une fois les traitements lancés, pour assurer l'adéquation entre l'objet dans Admin et les objets importés.
 
 Le champ `complete_types` est utile pour le comportement de compactage (cf paragraphe suivant). Les fichiers des types complets annulent et remplacent toutes les données précédemment importées pour ce type, alors que les autres viennent compléter les données passées.
@@ -133,7 +131,6 @@ Le champ `complete_types` est utile pour le comportement de compactage (cf parag
 Le champ `param` est utile pour le calcul des variables (cf le paragraphe à ce sujet). Il définit l'étendu des périodes à traiter et la dernière période pour laquelle les données d'effectif sont disponibles.
 
 Les types définis dans [handlers.go](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/dbmongo/handlers.go) (variable `registeredParsers`) sont accessibles via:
-
 
 ```
 http :3000/api/admin/types


### PR DESCRIPTION
Sur chaque commit de la branch `master` et chaque Pull Request, GitHub Actions vérifiera que les fichiers markdown ont bien été (re)formattés et que leurs tables des matières sont bien à jour.

Commande de formattage et mise à jour des tables des matières:

```sh
$ make
```
