### PR TITLE
feat: Documentation de commandes sfdata (CLI, au lieu de l'API dbmongo)

### DIFF
--- a/architecture-logicielle.md
+++ b/architecture-logicielle.md
@@ -183,7 +183,7 @@ Ce module est écrit en go (1.10) et centralise les fonctions de traitement des 
 
 ##### utilisation
 
-sfdata propose une api pour ordonner les traitements. Une documentation openapi est disponible [ici](https://raw.githubusercontent.com/signaux-faibles/opensignauxfaibles/master/sfdata/docs/swagger/swagger.yaml)
+`sfdata` est une commande (CLI) pour ordonner les traitements. Une documentation openapi est disponible [ici](https://raw.githubusercontent.com/signaux-faibles/opensignauxfaibles/master/sfdata/docs/swagger/swagger.yaml)
 
 #### module R/H2O
 

--- a/architecture-logicielle.md
+++ b/architecture-logicielle.md
@@ -185,7 +185,7 @@ Cette brique intègre le stockage de l'historique des données brutes, mais auss
 
 ##### utilisation
 
-`sfdata` est une commande (CLI) pour ordonner les traitements. Une documentation openapi est disponible [ici](https://raw.githubusercontent.com/signaux-faibles/opensignauxfaibles/master/sfdata/docs/swagger/swagger.yaml)
+`sfdata` est une commande (CLI) pour ordonner les traitements. Une documentation openapi est disponible [ici](https://raw.githubusercontent.com/signaux-faibles/opensignauxfaibles/master/docs/swagger/swagger.yaml)
 
 #### module R/H2O
 
@@ -215,7 +215,7 @@ Il lui incombe de fournir à datapi:
 - les listes de détection (niveau A)
 - les badges de sécurité pour tous les objets exportés afin d'appliquer les niveaux de sécurité.
 
-Ce traitement est écrit en dur dans le code de sfdata [ici](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/sfdata/lib/engine/datapi.go)
+Ce traitement est écrit en dur dans le code de sfdata [ici](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/lib/engine/datapi.go)
 
 ## datapi
 

--- a/architecture-logicielle.md
+++ b/architecture-logicielle.md
@@ -15,7 +15,7 @@
 - [opensignauxfaibles](#opensignauxfaibles)
   - [Objectif](#objectif-1)
   - [Modules](#modules)
-    - [dbmongo](#dbmongo)
+    - [sfdata](#sfdata)
       - [Dépendances logicielles](#d%C3%A9pendances-logicielles)
       - [utilisation](#utilisation)
     - [module R/H2O](#module-rh2o)
@@ -155,7 +155,7 @@ Cette brique intègre le stockage de l'historique des données brutes, mais auss
 
 ### Modules
 
-#### dbmongo
+#### sfdata
 
 Ce module est écrit en go (1.10) et centralise les fonctions de traitement des données suivantes:
 
@@ -183,7 +183,7 @@ Ce module est écrit en go (1.10) et centralise les fonctions de traitement des 
 
 ##### utilisation
 
-dbmongo propose une api pour ordonner les traitements. Une documentation openapi est disponible [ici](https://raw.githubusercontent.com/signaux-faibles/opensignauxfaibles/master/dbmongo/docs/swagger/swagger.yaml)
+sfdata propose une api pour ordonner les traitements. Une documentation openapi est disponible [ici](https://raw.githubusercontent.com/signaux-faibles/opensignauxfaibles/master/sfdata/docs/swagger/swagger.yaml)
 
 #### module R/H2O
 
@@ -193,13 +193,13 @@ Ce module permet le traitement algorithmique. (à écrire)
 
 ![schéma](architecture-logicielle/workflow-osf.png)
 
-1. Lecture des fichiers bruts ([dbmongo](#dbmongo))
-1. Les données brutes sont converties et insérées dans mongodb ([dbmongo](#dbmongo))
-1. Les données sont compactées dans mongodb par un traitement map-reduce ([dbmongo](#dbmongo))
-1. Les variables sont calculées dans mongodb par un traitement map-reduce ([dbmongo](#dbmongo))
+1. Lecture des fichiers bruts ([sfdata](#sfdata))
+1. Les données brutes sont converties et insérées dans mongodb ([sfdata](#sfdata))
+1. Les données sont compactées dans mongodb par un traitement map-reduce ([sfdata](#sfdata))
+1. Les variables sont calculées dans mongodb par un traitement map-reduce ([sfdata](#sfdata))
 1. Le traitement algorithmique est effectué par le module [R/H2O](#module-rh2o)
 1. Les résultats sont injectés dans mongodb par le module [R/H2O](#module-rh2o)
-1. Les données nécessaires au frontend sont exportées dans datapi par le module ([dbmongo](#dbmongo))
+1. Les données nécessaires au frontend sont exportées dans datapi par le module ([sfdata](#sfdata))
 
 Pour plus de détail sur le traitement des données et les transformations qui leur sont appliquées, voir [ici](processus-traitement-donnees.md).
 
@@ -213,7 +213,7 @@ Il lui incombe de fournir à datapi:
 - les listes de détection (niveau A)
 - les badges de sécurité pour tous les objets exportés afin d'appliquer les niveaux de sécurité.
 
-Ce traitement est écrit en dur dans le code de dbmongo [ici](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/dbmongo/lib/engine/datapi.go)
+Ce traitement est écrit en dur dans le code de sfdata [ici](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/sfdata/lib/engine/datapi.go)
 
 ## datapi
 

--- a/architecture-logicielle.md
+++ b/architecture-logicielle.md
@@ -201,7 +201,7 @@ Ce module permet le traitement algorithmique. (à écrire)
 1. Les variables sont calculées dans mongodb par un traitement map-reduce ([sfdata](#sfdata))
 1. Le traitement algorithmique est effectué par le module [R/H2O](#module-rh2o)
 1. Les résultats sont injectés dans mongodb par le module [R/H2O](#module-rh2o)
-1. Les données nécessaires au frontend sont exportées dans datapi par le module ([sfdata](#sfdata))
+1. Les données nécessaires au frontend sont exportées dans un format destiné à datapi par le module ([sfdata](#sfdata))
 
 Pour plus de détail sur le traitement des données et les transformations qui leur sont appliquées, voir [ici](processus-traitement-donnees.md).
 

--- a/architecture-logicielle.md
+++ b/architecture-logicielle.md
@@ -157,7 +157,7 @@ Cette brique intègre le stockage de l'historique des données brutes, mais auss
 
 #### sfdata
 
-Ce module est écrit en go (1.10) et centralise les fonctions de traitement des données suivantes:
+Écrit en Go, ce module centralise les fonctions de traitement des données suivantes:
 
 - analyse des fichiers bruts
 - conversion/insert dans mongodb
@@ -179,7 +179,9 @@ Ce module est écrit en go (1.10) et centralise les fonctions de traitement des 
 - https://github.com/spf13/viper
 - https://github.com/tealeg/xlsx
 - https://github.com/chrnin/gournal
-- mongodb 3.6
+- MongoDB 4.2
+
+> Note: Les dépendances et versions sont tenues à jour dans [README.md](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/README.md) et [go.mod](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/go.mod).
 
 ##### utilisation
 
@@ -423,7 +425,9 @@ Voici les paquets spécifiques au développement par ordre alphabétique :
 
 ### MongoDB
 
-La version de MongoDB utilisée est la 3.6.
+La version de MongoDB utilisée est la 4.2.
+
+> Note: Les dépendances et versions sont tenues à jour dans [README.md](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/README.md) et [go.mod](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/go.mod).
 
 ### Keycloak
 

--- a/prise-en-main.md
+++ b/prise-en-main.md
@@ -258,7 +258,7 @@ $ docker exec -it sf-mongodb mongo signauxfaibles
 
 ### 6. En cas d'erreur – afficher le journal de MongoDB
 
-Il peut arriver qu'un appel API de traitement de données échoue et retourne le message d'erreur suivant: `erreurs constatées, consultez les journaux`.
+Il peut arriver qu'un traitement de données échoue et retourne le message d'erreur suivant: `erreurs constatées, consultez les journaux`.
 
 Dans ce cas, vous pouvez trouver le détail de ces erreurs dans les logs de MongoDB:
 

--- a/prise-en-main.md
+++ b/prise-en-main.md
@@ -187,7 +187,6 @@ Exécutez les commandes suivantes:
 ```sh
 $ git clone https://github.com/signaux-faibles/opensignauxfaibles.git
 $ cd opensignauxfaibles
-$ cd sfdata
 $ go build
 $ cp config-sample.toml config.toml
 $ sed -i '' "s,/foo/bar/data-raw,${DATA_DIR}," config.toml
@@ -240,10 +239,11 @@ $ docker exec -it sf-mongodb mongo signauxfaibles
 
 ### 5. Exécution des calculs pour populer la collection "`Features`"
 
-Après avoir installé [HTTPie – command line HTTP client](https://httpie.org/), exécutez la commande suivante:
+Depuis `ssh centos@labtenant -t tmux att`:
 
 ```sh
-$ http :5000/api/data/reduce algo=algo2 batch=1910 key=012345678
+cd opensignauxfaibles
+./sfdata reduce --batch=1910 --key=012345678
 ```
 
 Puis vérifiez que la collection `Features_debug` a bien été populée par la chaine d'intégration:

--- a/prise-en-main.md
+++ b/prise-en-main.md
@@ -15,7 +15,7 @@
 - [Étape de calculs pour populer "`Features`"](#%C3%A9tape-de-calculs-pour-populer-features)
   - [1. Lancement de mongodb avec Docker](#1-lancement-de-mongodb-avec-docker)
   - [2. Préparation du répertoire de données `${DATA_DIR}`](#2-pr%C3%A9paration-du-r%C3%A9pertoire-de-donn%C3%A9es-data_dir)
-  - [3. Installation et configuration de `dbmongo`](#3-installation-et-configuration-de-dbmongo)
+  - [3. Installation et configuration de `sfdata`](#3-installation-et-configuration-de-sfdata)
   - [4. Ajout de données de test](#4-ajout-de-donn%C3%A9es-de-test)
   - [5. Exécution des calculs pour populer la collection "`Features`"](#5-ex%C3%A9cution-des-calculs-pour-populer-la-collection-features)
   - [6. En cas d'erreur – afficher le journal de MongoDB](#6-en-cas-derreur--afficher-le-journal-de-mongodb)
@@ -180,14 +180,14 @@ $ mkdir ${DATA_DIR}
 $ touch ${DATA_DIR}/dummy.csv
 ```
 
-### 3. Installation et configuration de `dbmongo`
+### 3. Installation et configuration de `sfdata`
 
 Exécutez les commandes suivantes:
 
 ```sh
 $ git clone https://github.com/signaux-faibles/opensignauxfaibles.git
 $ cd opensignauxfaibles
-$ cd dbmongo
+$ cd sfdata
 $ go build
 $ cp config-sample.toml config.toml
 $ sed -i '' "s,/foo/bar/data-raw,${DATA_DIR}," config.toml

--- a/prise-en-main.md
+++ b/prise-en-main.md
@@ -243,10 +243,10 @@ Depuis `ssh centos@labtenant -t tmux att`:
 
 ```sh
 cd opensignauxfaibles
-./sfdata reduce --until-batch=1910 --key=012345678
+./sfdata reduce --until-batch=1910
 ```
 
-Puis vérifiez que la collection `Features_debug` a bien été populée par la chaine d'intégration:
+Puis vérifiez que la collection `Features` a bien été populée par la chaine d'intégration:
 
 ```sh
 $ docker exec -it sf-mongodb mongo signauxfaibles

--- a/prise-en-main.md
+++ b/prise-en-main.md
@@ -243,7 +243,7 @@ Depuis `ssh centos@labtenant -t tmux att`:
 
 ```sh
 cd opensignauxfaibles
-./sfdata reduce --up-to-batch=1910 --key=012345678
+./sfdata reduce --until-batch=1910 --key=012345678
 ```
 
 Puis vérifiez que la collection `Features_debug` a bien été populée par la chaine d'intégration:

--- a/prise-en-main.md
+++ b/prise-en-main.md
@@ -243,7 +243,7 @@ Depuis `ssh centos@labtenant -t tmux att`:
 
 ```sh
 cd opensignauxfaibles
-./sfdata reduce --batch=1910 --key=012345678
+./sfdata reduce --up-to-batch=1910 --key=012345678
 ```
 
 Puis vérifiez que la collection `Features_debug` a bien été populée par la chaine d'intégration:

--- a/procedure-import-donnees.md
+++ b/procedure-import-donnees.md
@@ -213,7 +213,7 @@ Pour celà, utiliser la commande `sfdata pruneEntities` depuis `ssh centos@labte
 cd opensignauxfaibles
 
 # dry-run, pour compter les entités à supprimer
-./sfdata pruneEntities --batch=2010 --dry-run
+./sfdata pruneEntities --batch=2010 --count
 
 # après vérification, supprimer ces entités de RawData
 ./sfdata pruneEntities --batch=2010 --delete

--- a/procedure-import-donnees.md
+++ b/procedure-import-donnees.md
@@ -8,7 +8,7 @@
   - [Télécharger le fichier Siren](#t%C3%A9l%C3%A9charger-le-fichier-siren)
   - [Télécharger le fichier Diane](#t%C3%A9l%C3%A9charger-le-fichier-diane)
   - [Créer un objet admin pour l'intégration des données](#cr%C3%A9er-un-objet-admin-pour-lint%C3%A9gration-des-donn%C3%A9es)
-  - [(Re)lancer le serveur API `sfdata` (optionnel)](#relancer-le-serveur-api-sfdata-optionnel)
+  - [Mettre à jour la commande `sfdata` (optionnel)](#mettre-%C3%A0-jour-la-commande-sfdata-optionnel)
   - [Lancer l'import](#lancer-limport)
   - [Lancer le compactage](#lancer-le-compactage)
   - [Calcul des variables et génération de la liste de detection](#calcul-des-variables-et-g%C3%A9n%C3%A9ration-de-la-liste-de-detection)
@@ -139,13 +139,13 @@ Penser à changer le nom du batch en langage naturel: ex "Février 2020".
 
 Insérer le document résultant dans la collection `Admin`.
 
-## (Re)lancer le serveur API `sfdata` (optionnel)
+## Mettre à jour la commande `sfdata` (optionnel)
 
 Depuis `ssh centos@labtenant -t tmux att`:
 
 ```sh
 killall sfdata
-cd opensignauxfaibles/sfdata
+cd opensignauxfaibles
 git pull
 go build
 ./sfdata

--- a/procedure-import-donnees.md
+++ b/procedure-import-donnees.md
@@ -8,7 +8,7 @@
   - [Télécharger le fichier Siren](#t%C3%A9l%C3%A9charger-le-fichier-siren)
   - [Télécharger le fichier Diane](#t%C3%A9l%C3%A9charger-le-fichier-diane)
   - [Créer un objet admin pour l'intégration des données](#cr%C3%A9er-un-objet-admin-pour-lint%C3%A9gration-des-donn%C3%A9es)
-  - [(Re)lancer le serveur API `dbmongo` (optionnel)](#relancer-le-serveur-api-dbmongo-optionnel)
+  - [(Re)lancer le serveur API `sfdata` (optionnel)](#relancer-le-serveur-api-sfdata-optionnel)
   - [Lancer l'import](#lancer-limport)
   - [Lancer le compactage](#lancer-le-compactage)
   - [Calcul des variables et génération de la liste de detection](#calcul-des-variables-et-g%C3%A9n%C3%A9ration-de-la-liste-de-detection)
@@ -24,7 +24,7 @@ Cette procédure décrit:
 
 - la structure recommandée pour organiser les fichiers par (sous-)batch;
 - comment récupérer les fichiers de données de nos partenaires;
-- comment constituer un objet `batch` à partir de ces fichiers, en vue de les importer dans la base de données MongoDB, à l'aide de `dbmongo`. (cf [Processus de traitement des données](processus-traitement-donnees.md))
+- comment constituer un objet `batch` à partir de ces fichiers, en vue de les importer dans la base de données MongoDB, à l'aide de `sfdata`. (cf [Processus de traitement des données](processus-traitement-donnees.md))
 
 La plupart de ces opérations sont menées sur `stockage`, serveur sur lequel sont reçus et conservés les fichiers régulièrement transmis par nos partenaires.
 
@@ -139,16 +139,16 @@ Penser à changer le nom du batch en langage naturel: ex "Février 2020".
 
 Insérer le document résultant dans la collection `Admin`.
 
-## (Re)lancer le serveur API `dbmongo` (optionnel)
+## (Re)lancer le serveur API `sfdata` (optionnel)
 
 Depuis `ssh centos@labtenant -t tmux att`:
 
 ```sh
-killall dbmongo
-cd opensignauxfaibles/dbmongo
+killall sfdata
+cd opensignauxfaibles/sfdata
 git pull
 go build
-./dbmongo
+./sfdata
 ```
 
 > Documentation de référence: [API servie par Golang](processus-traitement-donnees.md#lapi-servie-par-golang)
@@ -185,7 +185,7 @@ http :3000/api/data/validate collection="RawData"      # valider les données d�
 Afficher les entrées de données invalides depuis `ssh centos@labtenant -t tmux att`:
 
 ```sh
-cd opensignauxfaibles/dbmongo
+cd opensignauxfaibles/sfdata
 zcat <nom_du_fichier_retourné_par_API>
 ```
 

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -79,8 +79,8 @@ Le workflow classique d'intégration consiste à:
   ./sfdata compact --since-batch="1904"
   ./sfdata validate --collection="RawData"
   # 3. Calcul et publication
-  ./sfdata reduce --up-to-batch="1904"
-  ./sfdata public --up-to-batch="1904"
+  ./sfdata reduce --until-batch="1904"
+  ./sfdata public --until-batch="1904"
   ```
 
 Au cours de l'import, un log des début et des fin d'intégration de fichiers et de types de fichiers sont loggés dans la collection `Journal`. (cf [Journalisation/Logging de l'intégration](journalisation-integration.md))
@@ -217,10 +217,10 @@ Le calcul des variables est lancé de la manière suivante:
 cd opensignauxfaibles
 ./sfdata reduce [options]
 # Par exemple
-./sfdata reduce --up-to-batch="1904" --key="01234567891011"
+./sfdata reduce --until-batch="1904" --key="01234567891011"
 ```
 
-Le paramètre obligatoire `up-to-batch` spécifie la clé du dernier batch intégré.
+Le paramètre obligatoire `until-batch` spécifie la clé du dernier batch intégré.
 
 Le paramètre facultatif `key` permet de ne faire tourner les calculs que pour un siret particulier, essentiellement pour des raisons de debugging. Les données sont alors importées dans la collection `Features_debug` plutôt que dans la collection `Features`.
 
@@ -232,7 +232,7 @@ La publication de variables est lancée de la manière suivante:
 cd opensignauxfaibles
 ./sfdata public [options]
 # Par exemple
-./sfdata public --up-to-batch="1904"
+./sfdata public --until-batch="1904"
 ```
 
-Le paramètre obligatoire `up-to-batch` spécifie la clé du dernier batch intégré.
+Le paramètre obligatoire `until-batch` spécifie la clé du dernier batch intégré.

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -21,8 +21,6 @@
 
 Dans cette partie, nous explorons comment les données sont importées puis transformées par `sfdata`, à partir des fichiers bruts.
 
-Note: Vous pouvez installer la commande `http` utilisée dans les exemples de cette page à partir de [HTTPie – command line HTTP client](https://httpie.org/).
-
 ## Vue d'ensemble des canaux de transformation des données
 
 Le schéma ci-dessous montre les différentes étapes de transformation des données.
@@ -59,10 +57,13 @@ Le workflow classique d'intégration consiste à:
 
 - Constituer un objet `batch` listant les fichiers de données à importer (cf [procédure avec `prepare-import`](procedure-import-donnees.md)), puis l'insérer dans la collection `Admin`.
 
-- Lancer l'API:
+- Mettre à jour la commande `sfdata`, depuis `ssh centos@labtenant -t tmux att`:
 
   ```sh
-  $ go build && ./sfdata
+  killall sfdata
+  cd opensignauxfaibles
+  git pull
+  go build
   ```
 
 - Appeler séquentiellement les fonctions d'intégration (et de contrôle) pour importer, compacter les données puis calculer les variables avec les options idoines:

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -9,7 +9,7 @@
   - [Étape 2 – Compactage](#%C3%A9tape-2--compactage)
   - [Étape 3 – Calcul des variables](#%C3%A9tape-3--calcul-des-variables)
 - [Workflow classique](#workflow-classique)
-- [L'API servie par Golang](#lapi-servie-par-golang)
+- [Commande `sfdata`](#commande-sfdata)
 - [La base de données MongoDB](#la-base-de-donn%C3%A9es-mongodb)
 - [Spécificités de l'import](#sp%C3%A9cificit%C3%A9s-de-limport)
 - [Spécificités du compactage](#sp%C3%A9cificit%C3%A9s-du-compactage)
@@ -85,19 +85,15 @@ Pendant le compactage et le calcul des variables, le log de MongoDB peut être c
 
 Entre ces traitements, une façon de s'assurer que le processus tourne est de vérifier qu'il n'y a pas d'erreur golang, et que MongoDB travaille, par exemple avec la commande _top_.
 
-## L'API servie par Golang
+## Commande `sfdata`
 
-L'intégralité des opérations sur les données se font au moyen d'une API servie par Golang, qui analyse et cadence les opérations à effectuer sur la base MongoDB.
+L'intégralité des opérations sur les données se font au moyen de la commande `sfdata` (_CLI_ anciennement connu sous le nom de `dbmongo`), qui analyse et cadence les opérations à effectuer sur la base MongoDB.
 
-L'API est ouverte avec la commande suivante, à exécuter dans le répertoire `./sfdata` du projet `opensignauxfaibles`.
+Elle est implémentée en Golang, au sein du projet `opensignauxfaibles`.
 
 ```sh
 $ go build && ./sfdata
 ```
-
-L'API est alors lancée sur `localhost`, par défaut sur le port `3000` (le port peut-être modifié dans le fichier `./sfdata/config.toml`)
-
-Cette API est documentée par swagger, et est alors accessible sur `localhost:3000/swagger/index.html`.
 
 Certaines des commandes seront plus amplement détaillées dans ce qui suit.
 

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -19,7 +19,7 @@
 
 ## Préambule
 
-Dans cette partie, nous explorons comment les données sont importées puis transformées par `dbmongo`, à partir des fichiers bruts.
+Dans cette partie, nous explorons comment les données sont importées puis transformées par `sfdata`, à partir des fichiers bruts.
 
 Note: Vous pouvez installer la commande `http` utilisée dans les exemples de cette page à partir de [HTTPie – command line HTTP client](https://httpie.org/).
 
@@ -62,7 +62,7 @@ Le workflow classique d'intégration consiste à:
 - Lancer l'API:
 
   ```sh
-  $ go build && ./dbmongo
+  $ go build && ./sfdata
   ```
 
 - Appeler séquentiellement les fonctions d'intégration (et de contrôle) pour importer, compacter les données puis calculer les variables avec les options idoines:
@@ -89,13 +89,13 @@ Entre ces traitements, une façon de s'assurer que le processus tourne est de v�
 
 L'intégralité des opérations sur les données se font au moyen d'une API servie par Golang, qui analyse et cadence les opérations à effectuer sur la base MongoDB.
 
-L'API est ouverte avec la commande suivante, à exécuter dans le répertoire `./dbmongo` du projet `opensignauxfaibles`.
+L'API est ouverte avec la commande suivante, à exécuter dans le répertoire `./sfdata` du projet `opensignauxfaibles`.
 
 ```sh
-$ go build && ./dbmongo
+$ go build && ./sfdata
 ```
 
-L'API est alors lancée sur `localhost`, par défaut sur le port `3000` (le port peut-être modifié dans le fichier `./dbmongo/config.toml`)
+L'API est alors lancée sur `localhost`, par défaut sur le port `3000` (le port peut-être modifié dans le fichier `./sfdata/config.toml`)
 
 Cette API est documentée par swagger, et est alors accessible sur `localhost:3000/swagger/index.html`.
 
@@ -103,7 +103,7 @@ Certaines des commandes seront plus amplement détaillées dans ce qui suit.
 
 ## La base de données MongoDB
 
-Le stockage des données se fait dans une base de données "objet", notre choix s'est porté sur MongoDB. L'adresse et le port de la base de données est spécifiée dans `./dbmongo/config.toml`.
+Le stockage des données se fait dans une base de données "objet", notre choix s'est porté sur MongoDB. L'adresse et le port de la base de données est spécifiée dans `./sfdata/config.toml`.
 
 Les différentes collections utilisées seront détaillées par la suite.
 
@@ -143,7 +143,7 @@ Le champ `complete_types` est utile pour le comportement de compactage (cf parag
 
 Le champ `param` est utile pour le calcul des variables (cf le paragraphe à ce sujet). Il définit l'étendu des périodes à traiter et la dernière période pour laquelle les données d'effectif sont disponibles.
 
-Les types définis dans [handlers.go](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/dbmongo/handlers.go) (variable `registeredParsers`) et reconnus par [prepare-import](https://github.com/signaux-faibles/prepare-import) sont accessibles via:
+Les types définis dans [handlers.go](https://github.com/signaux-faibles/opensignauxfaibles/blob/master/sfdata/handlers.go) (variable `registeredParsers`) et reconnus par [prepare-import](https://github.com/signaux-faibles/prepare-import) sont accessibles via:
 
 ```
 http :3000/api/admin/types

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -174,10 +174,14 @@ L'import est lancé de la manière suivante:
 cd opensignauxfaibles
 ./sfdata import [options]
 # Par exemple
-./sfdata import --batch="1904" --parsers="urssaf,diane"
+./sfdata import --batch="1904"
 ```
 
-Le paramètre obligatoire `batch` indique la clé du batch à importer. Le paramètre optionnel `parsers`, qui est entré sous forme de tableau, permet de sélectionner les parsers à faire tourner. Par défaut, tous les parsers du batch sont lancés, cette option permet de corriger un type de fichier en particulier en cas d'erreur pendant l'intégration.
+Le paramètre obligatoire `batch` indique la clé du batch à importer.
+
+Le paramètre optionnel `parsers` permet de sélectionner les parsers à employer. Cette option est pratique pour corriger un type de fichier en particulier, en cas d'erreur pendant l'intégration. Exemple: `--parsers="urssaf,diane"`.
+
+Par défaut, tous les parsers du batch sont employés.
 
 > Important: Pour prévenir l'intégration de données corrompues, nous recommandons l'usage de `./sfdata check` avant importation en base de données. (cf [Procédure d'importation de données](procedure-import-donnees.md))
 

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -217,12 +217,12 @@ Le calcul des variables est lancé de la manière suivante:
 cd opensignauxfaibles
 ./sfdata reduce [options]
 # Par exemple
-./sfdata reduce --until-batch="1904" --key="01234567891011"
+./sfdata reduce --until-batch="1904"
 ```
 
 Le paramètre obligatoire `until-batch` spécifie la clé du dernier batch intégré.
 
-Le paramètre facultatif `key` permet de ne faire tourner les calculs que pour un siret particulier, essentiellement pour des raisons de debugging. Les données sont alors importées dans la collection `Features_debug` plutôt que dans la collection `Features`.
+Le paramètre facultatif `key` permet de ne faire tourner les calculs que pour un siret particulier (ex: `--key="01234567891011"`), essentiellement pour des raisons de déboggage. Les données sont alors importées dans la collection `Features_debug` plutôt que dans la collection `Features`.
 
 ## Spécificités de la publication de données
 

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -195,10 +195,10 @@ Le compactage se lance avec la commande suivante:
 cd opensignauxfaibles
 ./sfdata compact [options]
 # Par exemple
-./sfdata compact --fromBatchKey="1804"
+./sfdata compact --since-batch="1804"
 ```
 
-L'option `fromBatchKey` indique le premier batch dans l'ordre alphabétique qui nécessite d'être compacté (c'est-à-dire qui a subi des changements). Tous les suivants le seront automatiquement.
+L'option `since-batch` indique le premier batch dans l'ordre alphabétique qui nécessite d'être compacté (c'est-à-dire qui a subi des changements). Tous les suivants le seront automatiquement.
 
 > Important: Le compactage est une opération difficilement réversible. Pour prévenir toute corruption de données et/ou interruption prématurée du compactage, nous recommandons de valider les données importées avant leur compactage, à l'aide de `./sfdata validate --collection="ImportedData"`. (cf [Procédure d'importation de données](procedure-import-donnees.md))
 

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -14,6 +14,7 @@
 - [Spécificités de l'import](#sp%C3%A9cificit%C3%A9s-de-limport)
 - [Spécificités du compactage](#sp%C3%A9cificit%C3%A9s-du-compactage)
 - [Spécificités des calculs de variables](#sp%C3%A9cificit%C3%A9s-des-calculs-de-variables)
+- [Spécificités de la publication de données](#sp%C3%A9cificit%C3%A9s-de-la-publication-de-donn%C3%A9es)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -76,9 +77,10 @@ Le workflow classique d'intégration consiste à:
   # 2. Compactage
   ./sfdata validate --collection="ImportedData"
   ./sfdata compact --fromBatchKey="1904"
-  # 3. Calcul
   ./sfdata validate --collection="RawData"
-  ./sfdata reduce --batch="1904"
+  # 3. Calcul et publication
+  ./sfdata reduce --up-to-batch="1904"
+  ./sfdata public --up-to-batch="1904"
   ```
 
 Au cours de l'import, un log des début et des fin d'intégration de fichiers et de types de fichiers sont loggés dans la collection `Journal`. (cf [Journalisation/Logging de l'intégration](journalisation-integration.md))
@@ -166,7 +168,7 @@ Les types reconnus sont listés dans [handlers.go](https://github.com/signaux-fa
 
 Les fichiers en provenance des urssaf ont été regroupées dans un parser spécifique du fait de leur dépendance à la table de correspondance entre comptes Urssaf et codes Siret, qui est ainsi chargée une seule fois en mémoire.
 
-L'import est lancé avec la requête:
+L'import est lancé de la manière suivante:
 
 ```sh
 cd opensignauxfaibles
@@ -205,15 +207,28 @@ L'option `fromBatchKey` indique le premier batch dans l'ordre alphabétique qui 
 TODO
 `param` dans la collection Admin
 
-Le calcul des variables est lancé via la requête:
+Le calcul des variables est lancé de la manière suivante:
 
 ```sh
 cd opensignauxfaibles
 ./sfdata reduce [options]
 # Par exemple
-./sfdata reduce --batch="1904" --key="01234567891011"
+./sfdata reduce --up-to-batch="1904" --key="01234567891011"
 ```
 
-Le paramètre obligatoire `batch` spécifie la clé du dernier batch intégré.
+Le paramètre obligatoire `up-to-batch` spécifie la clé du dernier batch intégré.
 
 Le paramètre facultatif `key` permet de ne faire tourner les calculs que pour un siret particulier, essentiellement pour des raisons de debugging. Les données sont alors importées dans la collection `Features_debug` plutôt que dans la collection `Features`.
+
+## Spécificités de la publication de données
+
+La publication de variables est lancée de la manière suivante:
+
+```sh
+cd opensignauxfaibles
+./sfdata public [options]
+# Par exemple
+./sfdata public --up-to-batch="1904"
+```
+
+Le paramètre obligatoire `up-to-batch` spécifie la clé du dernier batch intégré.

--- a/processus-traitement-donnees.md
+++ b/processus-traitement-donnees.md
@@ -76,7 +76,7 @@ Le workflow classique d'intégration consiste à:
   ./sfdata import --batch="1904"
   # 2. Compactage
   ./sfdata validate --collection="ImportedData"
-  ./sfdata compact --fromBatchKey="1904"
+  ./sfdata compact --since-batch="1904"
   ./sfdata validate --collection="RawData"
   # 3. Calcul et publication
   ./sfdata reduce --up-to-batch="1904"


### PR DESCRIPTION
Le but de cette PR est double:

1. dans un premier temps, discuter l'API de notre futur CLI `sfdata` (remplaçant du serveur `dbmongo`) au travers des appels fournis dans la documentation;
2. enfin, une fois que nous serons alignés sur cette API et que le CLI aura été développé, mettre à jour la documentation.

Voici les principes qui ont guidé les modifications apportées par cette PR:

- les traitements seront lancés via une commande `sfdata`, au lieu de requêtes HTTP vers le serveur `dbmongo`
- le code source de `sfdata` sera disponible à la racine du dépôt `opensignauxfaibles`, au lieu du sous-répertoire `dbmongo` (car la présence de notre module à l'intérieur de ce sous-répertoire déboussole l'éditeur que nous utilisons: vscode)
- pour rendre plus explicite le fait que les traitements `reduce` et `public` s'appliquent à l'ensemble des batches _jusqu'au_ batch spécifié, renommage du paramètre `--batch` en `--up-to-batch`
- nous continuerons, au moins dans un premier temps, de lancer les traitements depuis `labtenant`, alors que `stockage` sera principalement utilisé pour manipuler les fichiers lors de la préparation de batch à importer (à l'aide de `prepare-import`)
- inspiration de la philosophie de conception et usage des commandes UNIX/POSIX, telles que résumées dans le guide [Command Line Interface Guidelines](https://clig.dev/)